### PR TITLE
Conversion between D3D12 to DXVA Multiplier/StepSize semantics for Video Processing filters and Query caps

### DIFF
--- a/include/9on12VideoDevice.h
+++ b/include/9on12VideoDevice.h
@@ -22,8 +22,6 @@ namespace D3D9on12
 
         UINT GetMaxInputStreams() { return m_vpMaxInputStreams; }
 
-        FLOAT GetFilterRangeMultiplier(D3D12_VIDEO_PROCESS_FILTER filter) { return m_filterRanges[filter].Multiplier; }
-
         bool IsAutoProcessingSupported() { return m_pUnderlyingVideoProcessEnum->IsAutoProcessingSupported(); }
 
         bool IsAlphaBlendProcessingSupported() { return m_fAlphaBlending; }

--- a/include/9on12VideoDevice.h
+++ b/include/9on12VideoDevice.h
@@ -22,6 +22,8 @@ namespace D3D9on12
 
         UINT GetMaxInputStreams() { return m_vpMaxInputStreams; }
 
+        FLOAT GetFilterRangeMultiplier(D3D12_VIDEO_PROCESS_FILTER filter) { return m_filterRanges[filter].Multiplier; }
+
         bool IsAutoProcessingSupported() { return m_pUnderlyingVideoProcessEnum->IsAutoProcessingSupported(); }
 
         bool IsAlphaBlendProcessingSupported() { return m_fAlphaBlending; }

--- a/include/9on12VideoTranslate.h
+++ b/include/9on12VideoTranslate.h
@@ -501,32 +501,10 @@ namespace D3D9on12
                 assert(filter < cFilterRanges);
                 if (newMask & 0x1)
                 {
-                    // Conversion between D3D12 to DXVA Multiplier/StepSize semantics.
-                    // Need to de-normalize the d3d12 range expressed as an expanded scaled range with unitary integer steps to the DXVA expressed as an absolute range with the fractional step.
-                        // D3D12 semantics
-                        // https://docs.microsoft.com/zh-cn/windows-hardware/drivers/ddi/d3d12umddi/ns-d3d12umddi-d3d12ddi_video_process_filter_range_0020
-                        // The multiplier enables the filter range to have a fractional step value. For example, a hue filter might have an actual range of [–180.0 ... +180.0] with a step size of 0.25. 
-                        // The device would report the following range and multiplier:
-                        // Minimum: –720
-                        // Maximum : +720
-                        // Multiplier : 0.25
-                        // In this case, a filter value of 2 would be interpreted by the device as 0.50, which is 2 × 0.25.
-                        // The device should use a multiplier that can be represented exactly as a base - 2 fraction.
-                        //
-                        // DXVA semantics
-                        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/d3dumddi/ns-d3dumddi-_dxvaddi_valuerange
-                        // The range is expressed in absolute terms in Minimum, Maximum, Default. The allowed precision step between that range is defined in StepSize.
-                        // For example, a hue filter might have an actual range of [–180.0 ... +180.0] with a step size of 0.25. 
-                        // The device would report the following range and multiplier:
-                        // Minimum: –180
-                        // Maximum : +180
-                        // StepSize : 0.25
-
-                    pFilterRanges[filter].Minimum = static_cast<INT>(floor(dx12Support.FilterRangeSupport[filter].Minimum * dx12Support.FilterRangeSupport[filter].Multiplier));
-                    pFilterRanges[filter].Maximum = static_cast<INT>(floor(dx12Support.FilterRangeSupport[filter].Maximum * dx12Support.FilterRangeSupport[filter].Multiplier));
-                    pFilterRanges[filter].Default = static_cast<INT>(floor(dx12Support.FilterRangeSupport[filter].Default * dx12Support.FilterRangeSupport[filter].Multiplier));
+                    pFilterRanges[filter].Minimum = dx12Support.FilterRangeSupport[filter].Minimum;
+                    pFilterRanges[filter].Maximum = dx12Support.FilterRangeSupport[filter].Maximum;
+                    pFilterRanges[filter].Default = dx12Support.FilterRangeSupport[filter].Default;
                     pFilterRanges[filter].Multiplier = dx12Support.FilterRangeSupport[filter].Multiplier;
-                    DebugBreak();
                 }
                 newMask >>= 1;
                 ++filter;

--- a/include/9on12VideoTranslate.h
+++ b/include/9on12VideoTranslate.h
@@ -526,7 +526,6 @@ namespace D3D9on12
                     pFilterRanges[filter].Maximum = static_cast<INT>(floor(dx12Support.FilterRangeSupport[filter].Maximum * dx12Support.FilterRangeSupport[filter].Multiplier));
                     pFilterRanges[filter].Default = static_cast<INT>(floor(dx12Support.FilterRangeSupport[filter].Default * dx12Support.FilterRangeSupport[filter].Multiplier));
                     pFilterRanges[filter].Multiplier = dx12Support.FilterRangeSupport[filter].Multiplier;
-                    DebugBreak();
                 }
                 newMask >>= 1;
                 ++filter;

--- a/include/9on12VideoTranslate.h
+++ b/include/9on12VideoTranslate.h
@@ -501,10 +501,32 @@ namespace D3D9on12
                 assert(filter < cFilterRanges);
                 if (newMask & 0x1)
                 {
-                    pFilterRanges[filter].Minimum = dx12Support.FilterRangeSupport[filter].Minimum;
-                    pFilterRanges[filter].Maximum = dx12Support.FilterRangeSupport[filter].Maximum;
-                    pFilterRanges[filter].Default = dx12Support.FilterRangeSupport[filter].Default;
+                    // Conversion between D3D12 to DXVA Multiplier/StepSize semantics.
+                    // Need to de-normalize the d3d12 range expressed as an expanded scaled range with unitary integer steps to the DXVA expressed as an absolute range with the fractional step.
+                        // D3D12 semantics
+                        // https://docs.microsoft.com/zh-cn/windows-hardware/drivers/ddi/d3d12umddi/ns-d3d12umddi-d3d12ddi_video_process_filter_range_0020
+                        // The multiplier enables the filter range to have a fractional step value. For example, a hue filter might have an actual range of [–180.0 ... +180.0] with a step size of 0.25. 
+                        // The device would report the following range and multiplier:
+                        // Minimum: –720
+                        // Maximum : +720
+                        // Multiplier : 0.25
+                        // In this case, a filter value of 2 would be interpreted by the device as 0.50, which is 2 × 0.25.
+                        // The device should use a multiplier that can be represented exactly as a base - 2 fraction.
+                        //
+                        // DXVA semantics
+                        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/d3dumddi/ns-d3dumddi-_dxvaddi_valuerange
+                        // The range is expressed in absolute terms in Minimum, Maximum, Default. The allowed precision step between that range is defined in StepSize.
+                        // For example, a hue filter might have an actual range of [–180.0 ... +180.0] with a step size of 0.25. 
+                        // The device would report the following range and multiplier:
+                        // Minimum: –180
+                        // Maximum : +180
+                        // StepSize : 0.25
+
+                    pFilterRanges[filter].Minimum = static_cast<INT>(floor(dx12Support.FilterRangeSupport[filter].Minimum * dx12Support.FilterRangeSupport[filter].Multiplier));
+                    pFilterRanges[filter].Maximum = static_cast<INT>(floor(dx12Support.FilterRangeSupport[filter].Maximum * dx12Support.FilterRangeSupport[filter].Multiplier));
+                    pFilterRanges[filter].Default = static_cast<INT>(floor(dx12Support.FilterRangeSupport[filter].Default * dx12Support.FilterRangeSupport[filter].Multiplier));
                     pFilterRanges[filter].Multiplier = dx12Support.FilterRangeSupport[filter].Multiplier;
+                    DebugBreak();
                 }
                 newMask >>= 1;
                 ++filter;

--- a/src/9on12VideoProcessDevice.cpp
+++ b/src/9on12VideoProcessDevice.cpp
@@ -259,31 +259,7 @@ namespace D3D9on12
     void VideoProcessDevice::SetFilter(D3D12_VIDEO_PROCESS_FILTER filter, D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC *pStreamDesc, D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS1 *pStreamArguments, INT level)
     {
         pStreamDesc->FilterFlags |= (D3D12_VIDEO_PROCESS_FILTER_FLAGS)(1 << (UINT)filter);
-        
-        // Conversion between DXVA and D3D12 Multiplier/StepSize semantics.
-        // Need to re-normalize the DXVA range expressed as an absolute range with the fractional step to the D3D12 semantics as an expanded scaled range with unitary integer steps
-            // DXVA semantics
-            // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/d3dumddi/ns-d3dumddi-_dxvaddi_valuerange
-            // The range is expressed in absolute terms in Minimum, Maximum, Default. The allowed precision step between that range is defined in StepSize.
-            // For example, a hue filter might have an actual range of [–180.0 ... +180.0] with a step size of 0.25. 
-            // The device would report the following range and multiplier:
-            // Minimum: –180
-            // Maximum : +180
-            // StepSize : 0.25
-            // 
-            // D3D12 semantics
-            // https://docs.microsoft.com/zh-cn/windows-hardware/drivers/ddi/d3d12umddi/ns-d3d12umddi-d3d12ddi_video_process_filter_range_0020
-            // The multiplier enables the filter range to have a fractional step value. For example, a hue filter might have an actual range of [–180.0 ... +180.0] with a step size of 0.25. 
-            // The device would report the following range and multiplier:
-            // Minimum: –720
-            // Maximum : +720
-            // Multiplier : 0.25
-            // In this case, a filter value of 2 would be interpreted by the device as 0.50, which is 2 × 0.25.
-            // The device should use a multiplier that can be represented exactly as a base - 2 fraction.
-
-        FLOAT rangesMultiplier = m_pParentDevice->GetVideoDevice()->GetFilterRangeMultiplier(filter);
-        pStreamArguments->FilterLevels[filter] = static_cast<INT>(floor(level / rangesMultiplier));
-        DebugBreak();
+        pStreamArguments->FilterLevels[filter] = level;
     }
 
     _Use_decl_annotations_

--- a/src/9on12VideoProcessDevice.cpp
+++ b/src/9on12VideoProcessDevice.cpp
@@ -283,7 +283,6 @@ namespace D3D9on12
 
         FLOAT rangesMultiplier = m_pParentDevice->GetVideoDevice()->GetFilterRangeMultiplier(filter);
         pStreamArguments->FilterLevels[filter] = static_cast<INT>(floor(level / rangesMultiplier));
-        DebugBreak();
     }
 
     _Use_decl_annotations_

--- a/src/9on12VideoProcessDevice.cpp
+++ b/src/9on12VideoProcessDevice.cpp
@@ -259,7 +259,31 @@ namespace D3D9on12
     void VideoProcessDevice::SetFilter(D3D12_VIDEO_PROCESS_FILTER filter, D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC *pStreamDesc, D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS1 *pStreamArguments, INT level)
     {
         pStreamDesc->FilterFlags |= (D3D12_VIDEO_PROCESS_FILTER_FLAGS)(1 << (UINT)filter);
-        pStreamArguments->FilterLevels[filter] = level;
+        
+        // Conversion between DXVA and D3D12 Multiplier/StepSize semantics.
+        // Need to re-normalize the DXVA range expressed as an absolute range with the fractional step to the D3D12 semantics as an expanded scaled range with unitary integer steps
+            // DXVA semantics
+            // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/d3dumddi/ns-d3dumddi-_dxvaddi_valuerange
+            // The range is expressed in absolute terms in Minimum, Maximum, Default. The allowed precision step between that range is defined in StepSize.
+            // For example, a hue filter might have an actual range of [–180.0 ... +180.0] with a step size of 0.25. 
+            // The device would report the following range and multiplier:
+            // Minimum: –180
+            // Maximum : +180
+            // StepSize : 0.25
+            // 
+            // D3D12 semantics
+            // https://docs.microsoft.com/zh-cn/windows-hardware/drivers/ddi/d3d12umddi/ns-d3d12umddi-d3d12ddi_video_process_filter_range_0020
+            // The multiplier enables the filter range to have a fractional step value. For example, a hue filter might have an actual range of [–180.0 ... +180.0] with a step size of 0.25. 
+            // The device would report the following range and multiplier:
+            // Minimum: –720
+            // Maximum : +720
+            // Multiplier : 0.25
+            // In this case, a filter value of 2 would be interpreted by the device as 0.50, which is 2 × 0.25.
+            // The device should use a multiplier that can be represented exactly as a base - 2 fraction.
+
+        FLOAT rangesMultiplier = m_pParentDevice->GetVideoDevice()->GetFilterRangeMultiplier(filter);
+        pStreamArguments->FilterLevels[filter] = static_cast<INT>(floor(level / rangesMultiplier));
+        DebugBreak();
     }
 
     _Use_decl_annotations_


### PR DESCRIPTION
There's a semantic difference between how DXVA and D3D12 express the filter ranges and steps for video processing filters such as Contrast, Saturation, etc that was not addressed in 9on12. When enabling Video Processing Enhancement in Video Playback Settings, some video players are affected by this bug, rendering a black screen as processing the brightness/contrast when playing video. With this fix, the enhanced video plays correctly.