### PR TITLE
Update D3D12TranslationLayer SHA

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 FetchContent_Declare(
     d3d12translationlayer
     GIT_REPOSITORY https://github.com/microsoft/D3D12TranslationLayer.git
-    GIT_TAG        d27b59d5e9b28fe001c39dafa7ab573fbcaf416c
+    GIT_TAG        e1797c28f4345e70ae5a32ccec365b5b2bf65cb7
 )
 FetchContent_MakeAvailable(d3d12translationlayer)
 


### PR DESCRIPTION
New commits in this change:
* Use per-plane map refcounts instead of just a bitmask
* Revert PlaneIndex => Subresource change
* Revert additional PlaneIndex => Subresource changes
* Infer when memory was freed during ResourceAllocationFallback