### PR TITLE
Deduplicate shader objects created by apps

### DIFF
--- a/include/9on12Device.h
+++ b/include/9on12Device.h
@@ -104,6 +104,9 @@ namespace D3D9on12
 
         ShaderConv::ShaderConverterAPI m_ShaderConvAPI;
 
+        ShaderDedupe<VertexShader> m_VSDedupe;
+        ShaderDedupe<PixelShader> m_PSDedupe;
+
     protected:
         virtual void LogCreateVideoDevice( HRESULT hr );
 

--- a/include/9on12Shader.h
+++ b/include/9on12Shader.h
@@ -209,22 +209,19 @@ namespace D3D9on12
         struct DerivedVertexShaderKey : public DerivedShaderKey
         {
             // Hash in the constructor so that his key can be used several times efficiently
-            DerivedVertexShaderKey(const ShaderConv::RasterStates& rasterStates, InputLayout& inputLayout, WeakHash legacyByteCodeHash, _In_reads_(MAX_VERTEX_STREAMS) UINT* streamFrequencies) : DerivedShaderKey(rasterStates)
+            DerivedVertexShaderKey(const ShaderConv::RasterStates& rasterStates, InputLayout& inputLayout, _In_reads_(MAX_VERTEX_STREAMS) UINT* streamFrequencies) : DerivedShaderKey(rasterStates)
             {
                 //memcpy because assignment can add alignment which can throw off hashing
                 memcpy(&m_inputLayoutHash, &inputLayout.GetHash(), sizeof(m_inputLayoutHash));
-                memcpy(&m_legacyByteCodeHash, &legacyByteCodeHash, sizeof(m_legacyByteCodeHash));
                 memcpy(m_streamFrequencies, streamFrequencies, sizeof(m_streamFrequencies));
 
                 WeakHash hash = HashData(&m_rasterStates, sizeof(m_rasterStates), m_inputLayoutHash);//Add the hash from the IL
-                hash = HashData(&m_legacyByteCodeHash, sizeof(m_legacyByteCodeHash), hash);
                 hash = HashData(streamFrequencies, sizeof(streamFrequencies), hash);
                 m_hash = size_t(hash.m_data);
             };
 
             //Needs to be a deep copy as it's essentially a snapshot of the state at the time
             WeakHash m_inputLayoutHash;
-            WeakHash m_legacyByteCodeHash;
             UINT     m_streamFrequencies[MAX_VERTEX_STREAMS];
 
             struct Comparator
@@ -233,8 +230,7 @@ namespace D3D9on12
                 {
                     return memcmp(&a.m_rasterStates, &b.m_rasterStates, sizeof(a.m_rasterStates)) == 0 &&
                         memcmp(&a.m_streamFrequencies, &b.m_streamFrequencies, sizeof(a.m_streamFrequencies)) == 0 &&
-                        a.m_inputLayoutHash == b.m_inputLayoutHash &&
-                        a.m_legacyByteCodeHash == b.m_legacyByteCodeHash;
+                        a.m_inputLayoutHash == b.m_inputLayoutHash;
                 }
             };
         };
@@ -302,20 +298,18 @@ namespace D3D9on12
         struct DerivedPixelShaderKey : public DerivedShaderKey
         {
             // Hash in the constructor so that his key can be used several times efficiently
-            DerivedPixelShaderKey(const ShaderConv::RasterStates& rasterStates, ShaderConv::VSOutputDecls& vsOutDecls, WeakHash legacyByteCodeHash) : DerivedShaderKey(rasterStates)
+            DerivedPixelShaderKey(const ShaderConv::RasterStates& rasterStates, ShaderConv::VSOutputDecls& vsOutDecls) : DerivedShaderKey(rasterStates)
             {
                 //memcpy because assignment can add alignment which can throw off hashing
                 memcpy(&m_vsOutDecls, &vsOutDecls, sizeof(m_vsOutDecls));
-                memcpy(&m_legacyByteCodeHash, &legacyByteCodeHash, sizeof(m_legacyByteCodeHash));
-
-                WeakHash hash = HashData(&m_rasterStates, sizeof(m_rasterStates), m_legacyByteCodeHash);
+                
+                WeakHash hash = HashData(&m_rasterStates, sizeof(m_rasterStates));
                 hash = HashData(&m_vsOutDecls[0], m_vsOutDecls.GetSize() * sizeof(m_vsOutDecls[0]), hash);
                 m_hash = size_t(hash.m_data);
             };
 
             //Needs to be a deep copy as it's essentially a snapshot of the state at the time
             ShaderConv::VSOutputDecls m_vsOutDecls;
-            WeakHash m_legacyByteCodeHash;
 
             struct Comparator
             {
@@ -328,8 +322,7 @@ namespace D3D9on12
                         if (memcmp(&a.m_vsOutDecls[i], &b.m_vsOutDecls[i], sizeof(a.m_vsOutDecls[i])) != 0) { return false; }
                     }
 
-                    return memcmp(&a.m_rasterStates, &b.m_rasterStates, sizeof(a.m_rasterStates)) == 0 &&
-                        a.m_legacyByteCodeHash == b.m_legacyByteCodeHash;
+                    return memcmp(&a.m_rasterStates, &b.m_rasterStates, sizeof(a.m_rasterStates)) == 0;
                 }
             };
         };

--- a/include/9on12Shader.h
+++ b/include/9on12Shader.h
@@ -132,10 +132,9 @@ namespace D3D9on12
     class Shader : public PipelineStateCacheKeyComponent
     {
     public:
+        Shader(Device& device, _In_ CONST byte& byteCode, _In_ size_t byteCodeLength, WeakHash hash);
         Shader(Device& device);
         ~Shader();
-
-        HRESULT Init(_In_ CONST byte& byteCode, _In_ size_t byteCodeLength);
 
         static FORCEINLINE HANDLE GetHandleFromShader(Shader* pShader){ return static_cast<HANDLE>(pShader); }
         static FORCEINLINE Shader* GetShaderFromHandle(HANDLE hShader){ return static_cast<Shader*>(hShader); }
@@ -153,7 +152,7 @@ namespace D3D9on12
 
         SizedBuffer m_d3d9ByteCode;
 
-        WeakHash m_legacyCodeHash;
+        const WeakHash m_legacyCodeHash;
 
         CDXBCBuilder m_DXBCBuilder;
 
@@ -189,6 +188,7 @@ namespace D3D9on12
     {
     public:
 
+        VertexShader(Device& parentDevice, _In_ CONST byte& byteCode, _In_ size_t byteCodeLength, WeakHash hash);
         VertexShader(Device& parentDevice);
         ~VertexShader();
 
@@ -241,6 +241,7 @@ namespace D3D9on12
     class GeometryShader : public Shader
     {
     public:
+        GeometryShader(Device& parentDevice, _In_ CONST byte& byteCode, _In_ size_t byteCodeLength, WeakHash hash);
         GeometryShader(Device& parentDevice);
         ~GeometryShader();
 
@@ -286,7 +287,7 @@ namespace D3D9on12
     class PixelShader : public Shader
     {
     public:
-        PixelShader(Device& parentDevice);
+        PixelShader(Device& parentDevice, _In_ CONST byte& byteCode, _In_ size_t byteCodeLength, WeakHash hash);
         ~PixelShader();
 
         D3D12PixelShader& GetD3D12Shader(const ShaderConv::RasterStates &rasterStates, ShaderConv::VSOutputDecls& vsOutputDecls, D3D12Shader& inputShader);

--- a/include/9on12Shader.h
+++ b/include/9on12Shader.h
@@ -136,10 +136,14 @@ namespace D3D9on12
         Shader(Device& device);
         ~Shader();
 
+        void AddRef() { ++m_refCount; }
+        UINT Release() { return --m_refCount; }
+
         static FORCEINLINE HANDLE GetHandleFromShader(Shader* pShader){ return static_cast<HANDLE>(pShader); }
         static FORCEINLINE Shader* GetShaderFromHandle(HANDLE hShader){ return static_cast<Shader*>(hShader); }
 
         WeakHash GetHashForLegacyByteCode() { return m_legacyCodeHash; }
+        const SizedBuffer& GetLegacyByteCode() { return m_d3d9ByteCode; }
 
         HRESULT ShaderConversionPrologue();
     protected:
@@ -150,6 +154,7 @@ namespace D3D9on12
         static HRESULT DisassembleShader(CComPtr<ID3DBlob> &pBlob, const D3D12_SHADER_BYTECODE &shaderByteCode);
         static HRESULT ValidateShader(const D3D12_SHADER_BYTECODE &shaderByteCode);
 
+        UINT m_refCount = 1;
         SizedBuffer m_d3d9ByteCode;
 
         const WeakHash m_legacyCodeHash;

--- a/src/9on12Shader.cpp
+++ b/src/9on12Shader.cpp
@@ -16,8 +16,7 @@ namespace D3D9on12
 
         const byte* pShaderByteCode = (RegistryConstants::g_cDebugRedPixelShader) ? g_redOutputPS : (byte*)pByteCode;
         const size_t byteCodeSize = (RegistryConstants::g_cDebugRedPixelShader) ? sizeof(g_redOutputPS) : pCreatePixelShader->CodeSize;
-        WeakHash hash = HashData(pShaderByteCode, byteCodeSize);
-        PixelShader* pShader = new PixelShader(*pDevice, *pShaderByteCode, byteCodeSize, hash);
+        PixelShader* pShader = pDevice->m_PSDedupe.GetOrCreate(*pDevice, pShaderByteCode, byteCodeSize);
 
         pCreatePixelShader->ShaderHandle = Shader::GetHandleFromShader(pShader);
 
@@ -34,7 +33,7 @@ namespace D3D9on12
             RETURN_E_INVALIDARG_AND_CHECK();
         }
 
-        delete(pShader);
+        pDevice->m_PSDedupe.Release(static_cast<PixelShader*>(pShader));
 
         D3D9on12_DDI_ENTRYPOINT_END_AND_RETURN_HR(S_OK);
     }
@@ -49,8 +48,7 @@ namespace D3D9on12
         }
         const byte* pShaderByteCode = (RegistryConstants::g_cDebugPassThroughVertexShader) ? g_passThroughVS : (byte*)pByteCode;
         const size_t byteCodeSize = (RegistryConstants::g_cDebugPassThroughVertexShader) ? sizeof(g_passThroughVS) : pCreateVertexShader->Size;
-        WeakHash hash = HashData(pShaderByteCode, byteCodeSize);
-        VertexShader* pShader = new VertexShader(*pDevice, *pShaderByteCode, byteCodeSize, hash);
+        VertexShader* pShader = pDevice->m_VSDedupe.GetOrCreate(*pDevice, pShaderByteCode, byteCodeSize);
 
         pCreateVertexShader->ShaderHandle = Shader::GetHandleFromShader(pShader);
 
@@ -67,7 +65,7 @@ namespace D3D9on12
             RETURN_E_INVALIDARG_AND_CHECK();
         }
 
-        delete(pShader);
+        pDevice->m_VSDedupe.Release(pShader);
 
         D3D9on12_DDI_ENTRYPOINT_END_AND_RETURN_HR(S_OK);
     }

--- a/src/9on12Shader.cpp
+++ b/src/9on12Shader.cpp
@@ -188,7 +188,7 @@ namespace D3D9on12
     {
         HRESULT hr = S_OK;
 
-        DerivedPixelShaderKey key(rasterStates, vsOutputDecls, GetHashForLegacyByteCode());
+        DerivedPixelShaderKey key(rasterStates, vsOutputDecls);
 
         auto derivedShader = m_derivedShaders.find(key);
 
@@ -363,7 +363,7 @@ namespace D3D9on12
     {
         HRESULT hr = S_OK;
 
-        DerivedVertexShaderKey key(rasterStates, inputLayout, GetHashForLegacyByteCode(), m_parentDevice.GetPointerToStreamFrequencies());
+        DerivedVertexShaderKey key(rasterStates, inputLayout, m_parentDevice.GetPointerToStreamFrequencies());
 
         auto derivedShader = m_derivedShaders.find(key);
 
@@ -421,8 +421,7 @@ namespace D3D9on12
     {
         HRESULT hr = S_OK;
 
-        // note: we always give a constant hash for the legacy shader code because TL shaders don't have a VS.
-        DerivedVertexShaderKey key(rasterStates, inputLayout, WeakHash(0), m_parentDevice.GetPointerToStreamFrequencies());
+        DerivedVertexShaderKey key(rasterStates, inputLayout, m_parentDevice.GetPointerToStreamFrequencies());
 
         auto derivedShader = m_derivedShaders.find(key);
 


### PR DESCRIPTION
If an app creates identical shader objects, today we'll create multiple 9on12 shader objects. Each of these would then go on to create D3D12Shader derivations. And then each of those will eventually go on to create some PSOs. As a result, you can end up with a bunch of duplicated PSOs.

This adds a first-level dedupe step, so duplicate shaders from the app will just refcount in 9on12 instead.