### PR TITLE
Delete overzealous assert

### DIFF
--- a/include/9on12PipelineStateCache.h
+++ b/include/9on12PipelineStateCache.h
@@ -191,7 +191,6 @@ namespace D3D9on12
         };
         bool operator==(ShaderKey const& o) const
         {
-            assert(hash == o.hash);
             return size == o.size &&
                 (pBytecode == o.pBytecode ||
                     memcmp(pBytecode, o.pBytecode, size) == 0);


### PR DESCRIPTION
I'd assumed that if the comparison was running that the hash would have to match, but we're not necessarily getting bucketing in the hash map that's 1:1 with the incoming hashes.