### PR TITLE
Add support for setting MaxAllocatedUploadHeapSpacePerCommandList via app shim or registry

### DIFF
--- a/ShaderConverter/ShaderConv/context.cpp
+++ b/ShaderConverter/ShaderConv/context.cpp
@@ -3692,8 +3692,7 @@ CContext::EmitSrcOperand( const CInstr& instr,
 
     if (dwRegType == D3DSPR_TEXTURE)
     {
-        const DWORD dwRegNum = D3DSI_GETREGNUM_RESOLVING_CONSTANTS(dwToken) + dwOffset;
-        UNREFERENCED_PARAMETER(dwRegNum);
+        [[maybe_unused]] const DWORD dwRegNum = D3DSI_GETREGNUM_RESOLVING_CONSTANTS(dwToken) + dwOffset;
         SHADER_CONV_ASSERT(dwRegNum < MAX_PS_TEXCOORD_REGS);
     }
 

--- a/ShaderConverter/ShaderConv/context.cpp
+++ b/ShaderConverter/ShaderConv/context.cpp
@@ -3693,6 +3693,7 @@ CContext::EmitSrcOperand( const CInstr& instr,
     if (dwRegType == D3DSPR_TEXTURE)
     {
         const DWORD dwRegNum = D3DSI_GETREGNUM_RESOLVING_CONSTANTS(dwToken) + dwOffset;
+        UNREFERENCED_PARAMETER(dwRegNum);
         SHADER_CONV_ASSERT(dwRegNum < MAX_PS_TEXCOORD_REGS);
     }
 

--- a/ShaderConverter/ShaderConv/gsconv.cpp
+++ b/ShaderConverter/ShaderConv/gsconv.cpp
@@ -433,7 +433,7 @@ CGSContext::WriteOutputs()
     const bool isPointSizeEnable     = m_pShaderDesc->PointSizeEnable();
     const bool isPointFillEnable     = m_pShaderDesc->PointFillEnable();
     const bool isFlatColorFillEnable = m_pShaderDesc->FlatColorFillEnable();
-    const bool isPointSpriteEnable   = m_pShaderDesc->PointSpriteEnable();
+    [[maybe_unused]] const bool isPointSpriteEnable   = m_pShaderDesc->PointSpriteEnable();
     const bool isTextureWrapEnable   = m_pShaderDesc->TextureWrapEnable();
     const bool hasTLVertices         = m_pShaderDesc->HasTLVertices();
     const UINT userClipPlanes        = m_pShaderDesc->GetUserClipPlanes();
@@ -715,7 +715,6 @@ CGSContext::WriteOutputs()
                     }
                     else if (usage == D3DDECLUSAGE_POINTSPRITE)
                     {
-                        UNREFERENCED_PARAMETER(isPointSpriteEnable);
                         SHADER_CONV_ASSERT(isPointSpriteEnable);
                         const float vTexCoords[4][2] = {
                             { 0.0f, 0.0f },

--- a/ShaderConverter/ShaderConv/gsconv.cpp
+++ b/ShaderConverter/ShaderConv/gsconv.cpp
@@ -715,6 +715,7 @@ CGSContext::WriteOutputs()
                     }
                     else if (usage == D3DDECLUSAGE_POINTSPRITE)
                     {
+                        UNREFERENCED_PARAMETER(isPointSpriteEnable);
                         SHADER_CONV_ASSERT(isPointSpriteEnable);
                         const float vTexCoords[4][2] = {
                             { 0.0f, 0.0f },

--- a/include/9on12Registry.h
+++ b/include/9on12Registry.h
@@ -27,6 +27,7 @@ namespace D3D9on12
         static const LPCSTR g_cAnythingTimes0Equals0 = "AnythingTimes0Equals0";
         static const LPCSTR g_cPSOCacheTrimLimitSize = "PSOCacheTrimLimitSize";
         static const LPCSTR g_cPSOCacheTrimLimitAge = "PSOCacheTrimLimitAge";
+        static const LPCSTR g_cMaxAllocatedUploadHeapSpacePerCommandList = "MaxAllocatedUploadHeapSpacePerCommandList";
     };
 
     static DWORD CheckRegistryKeyDWORD(LPCSTR key, DWORD defaultValue = 0)
@@ -100,5 +101,6 @@ namespace D3D9on12
         static const bool g_cDisableMemoryManagement = CheckRegistryKey(RegistryKeys::g_cDisableMemoryManagement);
         static const DWORD g_cPSOCacheTrimLimitSize = CheckRegistryKeyDWORD(RegistryKeys::g_cPSOCacheTrimLimitSize, MAXDWORD);
         static const DWORD g_cPSOCacheTrimLimitAge = CheckRegistryKeyDWORD(RegistryKeys::g_cPSOCacheTrimLimitAge, MAXDWORD);
+        static const DWORD g_cMaxAllocatedUploadHeapSpacePerCommandList = CheckRegistryKeyDWORD(RegistryKeys::g_cMaxAllocatedUploadHeapSpacePerCommandList, MAXDWORD);
     };
 };

--- a/include/9on12Registry.h
+++ b/include/9on12Registry.h
@@ -28,6 +28,7 @@ namespace D3D9on12
         static const LPCSTR g_cPSOCacheTrimLimitSize = "PSOCacheTrimLimitSize";
         static const LPCSTR g_cPSOCacheTrimLimitAge = "PSOCacheTrimLimitAge";
         static const LPCSTR g_cMaxAllocatedUploadHeapSpacePerCommandList = "MaxAllocatedUploadHeapSpacePerCommandList";
+        static const LPCSTR g_cMaxSRVHeapSize = "MaxSRVHeapSize";        
     };
 
     static DWORD CheckRegistryKeyDWORD(LPCSTR key, DWORD defaultValue = 0)
@@ -102,5 +103,6 @@ namespace D3D9on12
         static const DWORD g_cPSOCacheTrimLimitSize = CheckRegistryKeyDWORD(RegistryKeys::g_cPSOCacheTrimLimitSize, MAXDWORD);
         static const DWORD g_cPSOCacheTrimLimitAge = CheckRegistryKeyDWORD(RegistryKeys::g_cPSOCacheTrimLimitAge, MAXDWORD);
         static const DWORD g_cMaxAllocatedUploadHeapSpacePerCommandList = CheckRegistryKeyDWORD(RegistryKeys::g_cMaxAllocatedUploadHeapSpacePerCommandList, MAXDWORD);
+        static const DWORD g_cMaxSRVHeapSize = CheckRegistryKeyDWORD(RegistryKeys::g_cMaxSRVHeapSize, MAXDWORD);
     };
 };

--- a/interface/d3d9on12ddi.h
+++ b/interface/d3d9on12ddi.h
@@ -182,6 +182,7 @@ typedef struct _D3D9ON12_APP_COMPAT_INFO
     DWORD AnythingTimes0Equals0ShaderMask;
     DWORD PSOCacheTrimLimitSize;  // PSO cache will be trimmed if its size is greater then this limit
     DWORD PSOCacheTrimLimitAge;   // We will only trim PSOs that are older then this age (age in command list age)
+    DWORD MaxAllocatedUploadHeapSpacePerCommandList; // Maximum amount of storage allocated for upload operations per command list before flush
 } D3D9ON12_APP_COMPAT_INFO;
 
 typedef void (APIENTRY *PFND3D9ON12_SETAPPCOMPATDATA)(

--- a/interface/d3d9on12ddi.h
+++ b/interface/d3d9on12ddi.h
@@ -183,6 +183,7 @@ typedef struct _D3D9ON12_APP_COMPAT_INFO
     DWORD PSOCacheTrimLimitSize;  // PSO cache will be trimmed if its size is greater then this limit
     DWORD PSOCacheTrimLimitAge;   // We will only trim PSOs that are older then this age (age in command list age)
     DWORD MaxAllocatedUploadHeapSpacePerCommandList; // Maximum amount of storage allocated for upload operations per command list before flush
+    DWORD MaxSRVHeapSize; // Maximum number of entries in the sharer resource view decriptor heap
 } D3D9ON12_APP_COMPAT_INFO;
 
 typedef void (APIENTRY *PFND3D9ON12_SETAPPCOMPATDATA)(

--- a/src/9on12AppCompat.cpp
+++ b/src/9on12AppCompat.cpp
@@ -9,7 +9,8 @@ namespace D3D9on12
         0, // AnythingTimes0Equals0ShaderMask
         MAXDWORD, // PSOCacheTrimLimitSize
         MAXDWORD, // PSOCacheTrimLimitAge
-        MAXDWORD  // MaxAllocatedUploadHeapSpacePerCommandList
+        MAXDWORD, // MaxAllocatedUploadHeapSpacePerCommandList
+        MAXDWORD, // MaxSRVHeapSize
     };
 
     void APIENTRY SetAppCompatData(const D3D9ON12_APP_COMPAT_INFO *pAppCompatData)

--- a/src/9on12AppCompat.cpp
+++ b/src/9on12AppCompat.cpp
@@ -8,7 +8,8 @@ namespace D3D9on12
     {
         0, // AnythingTimes0Equals0ShaderMask
         MAXDWORD, // PSOCacheTrimLimitSize
-        MAXDWORD  // PSOCacheTrimLimitAge
+        MAXDWORD, // PSOCacheTrimLimitAge
+        MAXDWORD  // MaxAllocatedUploadHeapSpacePerCommandList
     };
 
     void APIENTRY SetAppCompatData(const D3D9ON12_APP_COMPAT_INFO *pAppCompatData)

--- a/src/9on12Device.cpp
+++ b/src/9on12Device.cpp
@@ -405,6 +405,9 @@ namespace D3D9on12
 #ifdef __D3D9On12CreatorID_INTERFACE_DEFINED__
             args.CreatorID = __uuidof(D3D9On12CreatorID);
 #endif
+            args.MaxAllocatedUploadHeapSpacePerCommandList =
+                min(RegistryConstants::g_cMaxAllocatedUploadHeapSpacePerCommandList,
+                    g_AppCompatInfo.MaxAllocatedUploadHeapSpacePerCommandList);
 
             m_pImmediateContext.emplace(
                 0,

--- a/src/9on12Device.cpp
+++ b/src/9on12Device.cpp
@@ -409,6 +409,8 @@ namespace D3D9on12
                 min(RegistryConstants::g_cMaxAllocatedUploadHeapSpacePerCommandList,
                     g_AppCompatInfo.MaxAllocatedUploadHeapSpacePerCommandList);
 
+            args.MaxSRVHeapSize = min(RegistryConstants::g_cMaxSRVHeapSize, g_AppCompatInfo.MaxSRVHeapSize);
+
             m_pImmediateContext.emplace(
                 0,
                 FeatureDataD3D12,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 FetchContent_Declare(
     d3d12translationlayer
     GIT_REPOSITORY https://github.com/microsoft/D3D12TranslationLayer.git
-    GIT_TAG        e1797c28f4345e70ae5a32ccec365b5b2bf65cb7
+    GIT_TAG        af09819e9b60d3e589daf0ed49bf793583107bc2
 )
 FetchContent_MakeAvailable(d3d12translationlayer)
 


### PR DESCRIPTION
Add support for setting MaxAllocatedUploadHeapSpacePerCommandList via app shim or registry.
Add support for setting MaxSRVHeapSize via app shim or registry.
Also fix compiler warnings that show up on VS 2022.

This change requires a corresponding change to translation layer.
