### PR TITLE
User/tvandewalle/constant binding

### DIFF
--- a/include/9on12Constants.h
+++ b/include/9on12Constants.h
@@ -41,7 +41,7 @@ namespace D3D9on12
             m_allocator(device, 1024*1024, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT),
             m_shaderRegister(shaderRegister){};
 
-        HRESULT Version(const void* pData, UINT dataSize);
+        void Version(const void* pData, UINT dataSize);
         void Destroy();
 
         // Because a roll over may happen at any time, 
@@ -79,22 +79,22 @@ namespace D3D9on12
                 m_dataDirty = true;
             }
 
-            HRESULT UpdateData(Device& /*device*/, UINT maxSet)
+            Result UpdateData(Device& /*device*/, UINT maxSet)
             {
-                HRESULT hr = S_OK;
+                Result result = Result::S_SUCCESS;
                 // Even if the contents aren't dirty, we should update the data if 
                 // the maxSet has increased from the last binding
                 if ((m_dataDirty || maxSet > m_lastCopySize) && maxSet)
                 {
                     UINT dataSize = min(maxSet * m_sizePerElement, static_cast<UINT>(m_data.size()));
-                    hr = m_binding.Version(m_data.data(), dataSize);
+                    m_binding.Version(m_data.data(), dataSize);
 
                     m_dataDirty = false;
                     m_lastCopySize = maxSet;
+                    result = Result::S_CHANGE;
                 }
 
-                CHECK_HR(hr);
-                return hr;
+                return result;
             }
 
             void ReplaceResource(ConstantBufferBinding& nullCB)
@@ -138,8 +138,8 @@ namespace D3D9on12
                 }
             }
 
-            HRESULT UpdateAppVisibileBindings(Device& device, UINT maxFloats, UINT maxInts, UINT maxBools);
-            HRESULT BindAppVisibleToPipeline(Device& device, UINT maxFloats, UINT maxInts, UINT maxBools);
+            Result UpdateAppVisibileBindings(Device& device, UINT maxFloats, UINT maxInts, UINT maxBools);
+            void BindAppVisibleToPipeline(Device& device, UINT maxFloats, UINT maxInts, UINT maxBools);
             void NullOutBindings(Device& device, ConstantBufferBinding& nullCB);
 
         private:
@@ -196,17 +196,17 @@ namespace D3D9on12
 
         HRESULT Init();
 
-        HRESULT BindShaderConstants();
+        Result BindShaderConstants();
 
         VertexShaderConstants& GetVertexShaderConstants() { return m_vertexShaderData; }
         PixelShaderConstants& GetPixelShaderConstants() { return m_pixelShaderData; }
         ConstantBufferBinding& NullCB() { return m_nullCB; }
 
-        HRESULT UpdateVertexShaderExtension(const ShaderConv::VSCBExtension& data);
-        HRESULT UpdateGeometryShaderExtension(const ShaderConv::VSCBExtension& data);
-        HRESULT UpdatePixelShaderExtension(const ShaderConv::eConstantBuffers extension, const void* pData, size_t dataSize);
+        void UpdateVertexShaderExtension(const ShaderConv::VSCBExtension& data);
+        void UpdateGeometryShaderExtension(const ShaderConv::VSCBExtension& data);
+        Result UpdatePixelShaderExtension(const ShaderConv::eConstantBuffers extension, const void* pData, size_t dataSize);
 
-        static HRESULT BindToPipeline(Device& device, ConstantBufferBinding& buffer, D3D12TranslationLayer::EShaderStage shaderStage);
+        static void BindToPipeline(Device& device, ConstantBufferBinding& buffer, D3D12TranslationLayer::EShaderStage shaderStage);
 
     private:
 

--- a/include/9on12Constants.h
+++ b/include/9on12Constants.h
@@ -84,7 +84,7 @@ namespace D3D9on12
                 Result result = Result::S_SUCCESS;
                 // Even if the contents aren't dirty, we should update the data if 
                 // the maxSet has increased from the last binding
-                if ((m_dataDirty || maxSet > m_lastCopySize) && maxSet)
+                if (maxSet && (m_dataDirty || maxSet > m_lastCopySize))
                 {
                     UINT dataSize = min(maxSet * m_sizePerElement, static_cast<UINT>(m_data.size()));
                     m_binding.Version(m_data.data(), dataSize);
@@ -138,8 +138,7 @@ namespace D3D9on12
                 }
             }
 
-            Result UpdateAppVisibileBindings(Device& device, UINT maxFloats, UINT maxInts, UINT maxBools);
-            void BindAppVisibleToPipeline(Device& device, UINT maxFloats, UINT maxInts, UINT maxBools);
+            void UpdateAppVisibleAndBindToPipeline(Device& device, UINT maxFloats, UINT maxInts, UINT maxBools);
             void NullOutBindings(Device& device, ConstantBufferBinding& nullCB);
 
         private:
@@ -196,7 +195,7 @@ namespace D3D9on12
 
         HRESULT Init();
 
-        Result BindShaderConstants();
+        void BindShaderConstants();
 
         VertexShaderConstants& GetVertexShaderConstants() { return m_vertexShaderData; }
         PixelShaderConstants& GetPixelShaderConstants() { return m_pixelShaderData; }

--- a/src/9on12PipelineState.cpp
+++ b/src/9on12PipelineState.cpp
@@ -479,7 +479,7 @@ namespace D3D9on12
 
         m_dirtyFlags.Textures |= textureDirtyMaskToKeep;
 
-        hr = device.GetConstantsManager().BindShaderConstants();
+        hr = device.GetConstantsManager().BindShaderConstants().AsHresult();
         CHECK_HR(hr);
 
         return hr;

--- a/src/9on12PipelineState.cpp
+++ b/src/9on12PipelineState.cpp
@@ -479,7 +479,7 @@ namespace D3D9on12
 
         m_dirtyFlags.Textures |= textureDirtyMaskToKeep;
 
-        hr = device.GetConstantsManager().BindShaderConstants().AsHresult();
+        device.GetConstantsManager().BindShaderConstants();
         CHECK_HR(hr);
 
         return hr;

--- a/src/9on12VertexStage.cpp
+++ b/src/9on12VertexStage.cpp
@@ -246,8 +246,7 @@ namespace D3D9on12
 
         if (m_dirtyFlags.VSExtension)
         {
-            hr = device.GetConstantsManager().UpdateVertexShaderExtension(m_VSExtension.GetVSCBExtension());
-            CHECK_HR(hr);
+            device.GetConstantsManager().UpdateVertexShaderExtension(m_VSExtension.GetVSCBExtension());
         }
 
         if (m_dirtyFlags.VertexShader || m_dirtyFlags.InputLayout)
@@ -303,8 +302,7 @@ namespace D3D9on12
             {
                 m_pCurrentD3D12GS = &geo;
 
-                hr = device.GetConstantsManager().UpdateGeometryShaderExtension(m_VSExtension.GetVSCBExtension());
-                CHECK_HR(hr);
+                device.GetConstantsManager().UpdateGeometryShaderExtension(m_VSExtension.GetVSCBExtension());
             }
         }
         else


### PR DESCRIPTION
Based on some preliminary testing with WPA, this seems to reduce calls to BindToPipeline in half.

Also standardized some of the formatting for 9on12Constants.cpp. It seemed to originally be half and half on a couple things that vscode and visual studio were fighting over, so I just let visual studio win the formatting war.