### PR TITLE
Add support for D3DRS_CLIPPING

### DIFF
--- a/src/9on12PipelineState.cpp
+++ b/src/9on12PipelineState.cpp
@@ -68,6 +68,7 @@ namespace D3D9on12
         case D3DRS_SLOPESCALEDEPTHBIAS:
         case D3DRS_MULTISAMPLEANTIALIAS:
         case D3DRS_ANTIALIASEDLINEENABLE:
+        case D3DRS_CLIPPING:
             m_pixelStage.SetRasterState(dwState, dwValue);
             break;
             // DepthStencil states  

--- a/src/9on12PixelStage.cpp
+++ b/src/9on12PixelStage.cpp
@@ -189,6 +189,7 @@ namespace D3D9on12
 
     HRESULT PixelStage::Init(Device& /*device*/)
     {
+        SetRasterState(D3DRS_CLIPPING, 1); //d3d9 defaults this raster state to 1
         return S_OK;
     }
 
@@ -341,6 +342,10 @@ namespace D3D9on12
             m_rasterizerStateID.AntialiasedLineEnable = dwValue;
             m_dirtyFlags.RasterizerState = true;
             break;
+        case D3DRS_CLIPPING:
+            m_rasterizerStateID.DepthClipEnable = dwValue;
+            m_dirtyFlags.RasterizerState = true;
+            break;
         default:
             Check9on12(false);
         }
@@ -355,7 +360,6 @@ namespace D3D9on12
             // DepthStencil states  
         case D3DRS_ZENABLE:
             m_depthStencilStateID.ZEnable = dwValue;
-            m_rasterizerStateID.DepthClipEnable = dwValue;
             m_dirtyFlags.DepthStencilState = true;
             m_dirtyFlags.RasterizerState = true;
             break;


### PR DESCRIPTION
Depth clipping had been incorrectly tied to depth testing.
We were actually completely ignoring this render state, which led to
some annoying bugs.