### PR TITLE
Fix UpdateAppVisibleAndBindToPipeline to update boolean data

### DIFF
--- a/src/9on12Constants.cpp
+++ b/src/9on12Constants.cpp
@@ -186,7 +186,8 @@ namespace D3D9on12
             BindToPipeline(device, m_integers.m_binding, m_shaderType);
         }
 
-        if (maxBools)
+        result = m_booleans.UpdateData(device, maxBools);
+        if (maxBools && result == Result::S_CHANGE)
         {
             BindToPipeline(device, m_booleans.m_binding, m_shaderType);
         }


### PR DESCRIPTION
Noticed that the calls to UpdateData weren't adding up in some profiling data. Apparently calling UpdateData on m_booleans got dropped out of the last PR.