### PR TITLE
Claim support for Dither

### DIFF
--- a/include/9on12Caps.h
+++ b/include/9on12Caps.h
@@ -94,7 +94,7 @@ namespace D3D9on12
         D3DPMISCCAPS_POSTBLENDSRGBCONVERT |
         0,
         // RasterCaps,  
-        //D3DPRASTERCAPS_DITHER |  
+        D3DPRASTERCAPS_DITHER |  
         //D3DPRASTERCAPS_ROP2 |  
         //D3DPRASTERCAPS_XOR |  
         //D3DPRASTERCAPS_PAT |  
@@ -838,7 +838,7 @@ namespace D3D9on12
             0,
 
             // dwRasterCaps
-            //D3DPRASTERCAPS_DITHER |
+            D3DPRASTERCAPS_DITHER |
             //D3DPRASTERCAPS_ROP2 |
             //D3DPRASTERCAPS_XOR |
             //D3DPRASTERCAPS_PAT |
@@ -1060,7 +1060,7 @@ namespace D3D9on12
             0,
 
             // dwRasterCaps
-            //D3DPRASTERCAPS_DITHER |
+            D3DPRASTERCAPS_DITHER |
             //D3DPRASTERCAPS_ROP2 |
             //D3DPRASTERCAPS_XOR |
             //D3DPRASTERCAPS_PAT |


### PR DESCRIPTION
Dithering only really made sense when rendering to reduced bit-depth
formats (565, 5551, etc), but DX9 era hardware generally had 8 bit
precision in pixel shaders anyway so it was usually a noop when outputting to an 8 bit per channel format. DXVK also
chose to simply ignore dithering, so we should be fine to claim support
but not actually do anything.