### PR TITLE
CBV Read Fix

### DIFF
--- a/include/9on12Constants.h
+++ b/include/9on12Constants.h
@@ -207,6 +207,7 @@ namespace D3D9on12
 
         static void BindToPipeline(Device& device, ConstantBufferBinding& buffer, D3D12TranslationLayer::EShaderStage shaderStage);
 
+        static const size_t g_cMaxConstantBufferSize = 256 * sizeof(float);
     private:
 
         Device &m_device;
@@ -214,7 +215,6 @@ namespace D3D9on12
         GeometryShaderConstants m_geometryShaderData;
         PixelShaderConstants m_pixelShaderData;
 
-        static const size_t g_cMaxConstantBufferSize = 256 * sizeof(float);
         ConstantBufferBinding m_nullCB;
     };
 

--- a/include/9on12Device.h
+++ b/include/9on12Device.h
@@ -90,8 +90,8 @@ namespace D3D9on12
         {
             const UINT CONSTANT_BUFFER_ELEMENT_SIZE = sizeof(FLOAT) * 4;
             UINT firstConstant = offsetInBytes / CONSTANT_BUFFER_ELEMENT_SIZE;
-            UINT maxConstantBufferElements = ConstantsManager::g_cMaxConstantBufferSize / sizeof(FLOAT);
-            GetContext().SetConstantBuffers<ShaderStage>(shaderRegister, 1, &pResource, &firstConstant, (UINT *)&maxConstantBufferElements);
+            UINT maxConstantBufferElements = ConstantsManager::g_cMaxConstantBufferSize / CONSTANT_BUFFER_ELEMENT_SIZE;
+            GetContext().SetConstantBuffers<ShaderStage>(shaderRegister, 1, &pResource, &firstConstant, &maxConstantBufferElements);
         }
 
         void EnsureVideoDevice();

--- a/include/9on12Device.h
+++ b/include/9on12Device.h
@@ -90,7 +90,8 @@ namespace D3D9on12
         {
             const UINT CONSTANT_BUFFER_ELEMENT_SIZE = sizeof(FLOAT) * 4;
             UINT firstConstant = offsetInBytes / CONSTANT_BUFFER_ELEMENT_SIZE;
-            GetContext().SetConstantBuffers<ShaderStage>(shaderRegister, 1, &pResource, &firstConstant, nullptr);
+            UINT maxConstantBufferElements = ConstantsManager::g_cMaxConstantBufferSize / sizeof(FLOAT);
+            GetContext().SetConstantBuffers<ShaderStage>(shaderRegister, 1, &pResource, &firstConstant, (UINT *)&maxConstantBufferElements);
         }
 
         void EnsureVideoDevice();


### PR DESCRIPTION
Ensure that a shader reads 0 if it attempts to read beyond the end of the CBV.