### PR TITLE
Add tracking for drawing PreTransformedVertices

### DIFF
--- a/include/9on12Device.h
+++ b/include/9on12Device.h
@@ -109,6 +109,7 @@ namespace D3D9on12
         ShaderDedupe<PixelShader> m_PSDedupe;
 
         D3D12TranslationLayer::COptLockedContainer<std::unordered_map<Resource*, std::vector<LockRange>>> m_lockedResourceRanges;
+        void SetDrawingPreTransformedVerts(bool preTransformedVerts);
 
     protected:
         virtual void LogCreateVideoDevice( HRESULT hr );
@@ -160,5 +161,7 @@ namespace D3D9on12
 
         BYTE m_pVideoDeviceSpace[sizeof(VideoDevice)];
         VideoDevice *m_pVideoDevice;
+
+        bool m_drawingPreTransformedVerts = false;
     };
 };

--- a/include/9on12PipelineStateStructures.h
+++ b/include/9on12PipelineStateStructures.h
@@ -88,6 +88,7 @@ namespace D3D9on12
                 UINT MultiSampleAntiAlias : 1;
                 UINT AntialiasedLineEnable : 1;
                 UINT DepthClipEnable : 1;
+                UINT DrawingPreTransformedVertices : 1;
             };
         };
         FLOAT DepthBias;
@@ -333,7 +334,15 @@ namespace D3D9on12
             }
         }
         rasterizerDesc.DepthBiasClamp = 0.0f;
-        rasterizerDesc.DepthClipEnable = rasterizerID.DepthClipEnable ? TRUE : FALSE;
+
+        if (rasterizerID.DrawingPreTransformedVertices && !bDepthEnabledAndBound)
+        {
+            rasterizerDesc.DepthClipEnable = false;
+        }
+        else
+        {
+            rasterizerDesc.DepthClipEnable = rasterizerID.DepthClipEnable ? TRUE : FALSE;
+        }
 
         rasterizerDesc.AntialiasedLineEnable = rasterizerID.AntialiasedLineEnable ? TRUE : FALSE;
 

--- a/include/9on12PixelStage.h
+++ b/include/9on12PixelStage.h
@@ -32,6 +32,7 @@ namespace D3D9on12
         void SetBlendState(Device& device, DWORD dwState, DWORD dwValue);
         void SetPSExtensionState(DWORD dwState, DWORD dwValue);
         void SetPSExtension2State(DWORD dwStage, DWORD dwState, DWORD dwValue);
+        void SetPreTransformedVertexMode(bool drawingPretransformedVerts);
 
         HRESULT ResolveDeferredState(Device &device, D3D12_GRAPHICS_PIPELINE_STATE_DESC& psoDesc, UINT& textureDirtyMaskToKeep);
 

--- a/include/9on12draw.inl
+++ b/include/9on12draw.inl
@@ -64,6 +64,7 @@ namespace D3D9on12
             RETURN_E_INVALIDARG_AND_CHECK();
         }
 
+        pDevice->SetDrawingPreTransformedVerts(false);
         OffsetArg baseVertexOffset = OffsetArg::AsOffsetInVertices(pDrawPrimitiveArg->VStart);
         OffsetArg baseIndexOffset = OffsetArg::AsOffsetInIndices(0);
 
@@ -117,6 +118,7 @@ namespace D3D9on12
         UINT const stream0Stride = pDevice->GetPipelineState().GetInputAssembly().GetStream0Stride();
         Check9on12(stream0Stride > 0);
 
+        pDevice->SetDrawingPreTransformedVerts(true);
         OffsetArg baseVertexOffset = OffsetArg::AsOffsetInBytes(pDrawPrimitiveArg->FirstVertexOffset);
         OffsetArg baseIndexOffset = OffsetArg::AsOffsetInIndices(0);
 
@@ -166,6 +168,7 @@ namespace D3D9on12
         UINT const stream0Stride = pDevice->GetPipelineState().GetInputAssembly().GetStream0Stride();
         Check9on12(stream0Stride > 0);
 
+        pDevice->SetDrawingPreTransformedVerts(true);
         bool bNegativeVertexOffset = pData->BaseVertexOffset < 0;
         OffsetArg baseVertexOffset = OffsetArg::AsOffsetInBytes(pData->BaseVertexOffset);
         OffsetArg drawOffset = OffsetArg::AsOffsetInVertices(0);
@@ -468,6 +471,7 @@ namespace D3D9on12
         UINT StartInstanceLocation = 0;
         const UINT vertexCount = pDrawPrimitiveArg->MinIndex + pDrawPrimitiveArg->NumVertices;
 
+        pDevice->SetDrawingPreTransformedVerts(false);
         OffsetArg baseIndexOffset = OffsetArg::AsOffsetInIndices(pDrawPrimitiveArg->StartIndex);
         OffsetArg baseVertexOffset = OffsetArg::AsOffsetInVertices(pDrawPrimitiveArg->BaseVertexIndex);
 

--- a/src/9on12Device.cpp
+++ b/src/9on12Device.cpp
@@ -544,4 +544,12 @@ namespace D3D9on12
         //Do nothing
         UNREFERENCED_PARAMETER( hr );
     }
+
+    void Device::SetDrawingPreTransformedVerts(bool preTransformedVerts)
+    {
+        if (preTransformedVerts != m_drawingPreTransformedVerts)
+        {
+            GetPipelineState().GetPixelStage().SetPreTransformedVertexMode(preTransformedVerts);
+        }
+    }
 };

--- a/src/9on12PixelStage.cpp
+++ b/src/9on12PixelStage.cpp
@@ -634,6 +634,15 @@ namespace D3D9on12
         }
     }
 
+    void PixelStage::SetPreTransformedVertexMode(bool drawingPretransformedVerts)
+    {
+        if (static_cast<UINT>(drawingPretransformedVerts) != m_rasterizerStateID.DrawingPreTransformedVertices)
+        {
+            m_rasterizerStateID.DrawingPreTransformedVertices = drawingPretransformedVerts;
+            m_dirtyFlags.RasterizerState = true;
+        }
+    }
+
     void PixelStage::ResolveRenderTargets(Device &device, D3D12_GRAPHICS_PIPELINE_STATE_DESC& psoDesc, bool bDSVBound)
     {
         psoDesc.NumRenderTargets = m_numBoundRenderTargets;


### PR DESCRIPTION
In D3D9 it was possible to pre transform and light vertices before
drawing. This process also allowed culling, so the GPU wouldn't cull in
this case. The DDIs that correspond to this for 9on12 are the
DrawPrimitive2 and DrawIndexedPrimitive2 calls, so we need to keep track
of which "mode" we are in so that we don't cull/clip when we shouldn't.