### PR TITLE
MaxConstantBufferSize should have been 256 float4s, not 256 floats

### DIFF
--- a/include/9on12Constants.h
+++ b/include/9on12Constants.h
@@ -207,7 +207,7 @@ namespace D3D9on12
 
         static void BindToPipeline(Device& device, ConstantBufferBinding& buffer, D3D12TranslationLayer::EShaderStage shaderStage);
 
-        static const size_t g_cMaxConstantBufferSize = 256 * sizeof(float);
+        static const size_t g_cMaxConstantBufferSize = 256 * (sizeof(float) * 4); //256 float4 registers
     private:
 
         Device &m_device;


### PR DESCRIPTION
Since we weren't ensuring that a shader reads 0 if it attempts to read beyond the end of the CBV prior to #34, this issue was hidden due to writing and reading off the end of memory that we'd actually allocated for this constant buffer, but likely the culprit of some strange, unresolved bugs we've seen in the past. Yikes!