### PR TITLE
[LockDiscard Optimization] Check ValidRange flag and container optimization

### DIFF
--- a/src/9on12Resource.cpp
+++ b/src/9on12Resource.cpp
@@ -1388,21 +1388,23 @@ namespace D3D9on12
         {
             if (flags.RangeValid && (mapType == D3D12TranslationLayer::MAP_TYPE_WRITE_DISCARD))
             {
-                auto lockedResourceRanges = device.m_lockedResourceRanges.GetLocked();
-
                 // Check if buffer is in the map
                 // If it is, get a list of previously mapped ranges
-                if (lockedResourceRanges->count(this))
-                {
+
+                auto lockedResourceRanges = device.m_lockedResourceRanges.GetLocked();
+                auto it = lockedResourceRanges->find(this);
+                if (it != lockedResourceRanges->end()) {
+
+                    // it->second has the mapped ranges vector corresponding to it->first == this
+
                     bool overlapsWithPreviouslyMappedRanges = false;
                     bool mergedWithExistingMappedRange = false;
 
                     UINT currentRangeStart = lockRange.Range.Offset;
                     UINT currentRangeEnd = lockRange.Range.Offset + lockRange.Range.Size;
 
-                    auto &mappedRanges = lockedResourceRanges->at(this);
                     // Compare current range with previously mapped ranges
-                    for (auto& mappedRange : mappedRanges)
+                    for (auto& mappedRange : it->second)
                     {
                         UINT mappedRangeStart = mappedRange.Range.Offset;
                         UINT mappedRangeEnd = mappedRange.Range.Offset + mappedRange.Range.Size;
@@ -1439,12 +1441,12 @@ namespace D3D9on12
                     }
                     else // Else clear the list of ranges, add the current range, and keep the DISCARD flag
                     {
-                        lockedResourceRanges->at(this).clear();
+                        it->second.clear();
                     }
 
                     if (!mergedWithExistingMappedRange)
                     {
-                        lockedResourceRanges->at(this).push_back(lockRange);
+                        it->second.push_back(lockRange);
                     }
                 }
                 else

--- a/src/9on12Resource.cpp
+++ b/src/9on12Resource.cpp
@@ -1386,8 +1386,16 @@ namespace D3D9on12
 
         if (RegistryConstants::g_cLockDiscardOptimization)
         {
-            if (flags.RangeValid && (mapType == D3D12TranslationLayer::MAP_TYPE_WRITE_DISCARD))
+            if (mapType == D3D12TranslationLayer::MAP_TYPE_WRITE_DISCARD)
             {
+                // Range not valid means the whole resource is mapped
+                if(!flags.RangeValid)
+                {
+                    lockRange.Range.Offset = 0;
+                    assert(this->m_totalSize <= UINT_MAX); // For casting below
+                    lockRange.Range.Size = (UINT) this->m_totalSize;
+                }
+
                 // Check if buffer is in the map
                 // If it is, get a list of previously mapped ranges
 

--- a/src/9on12Resource.cpp
+++ b/src/9on12Resource.cpp
@@ -1386,7 +1386,7 @@ namespace D3D9on12
 
         if (RegistryConstants::g_cLockDiscardOptimization)
         {
-            if (mapType == D3D12TranslationLayer::MAP_TYPE_WRITE_DISCARD)
+            if (flags.RangeValid && (mapType == D3D12TranslationLayer::MAP_TYPE_WRITE_DISCARD))
             {
                 auto lockedResourceRanges = device.m_lockedResourceRanges.GetLocked();
 


### PR DESCRIPTION
Addresses comments left in https://github.com/microsoft/D3D9On12/pull/29

[Only do lock discard ranges optimization if flags.RangeValid is true](https://github.com/microsoft/D3D9On12/commit/678fe90da506ace4be87a2e427b750f22fc552b0)
[[LockDiscard Optimization] Use find() instead of at() and count() as perf. optimization](https://github.com/microsoft/D3D9On12/commit/9af3d83226cba8f146b0b59a1580f22bae8f3189) 
