### PR TITLE
[DX9]Cities: Skylines - Invisible water

### DIFF
--- a/include/9on12PipelineState.h
+++ b/include/9on12PipelineState.h
@@ -27,6 +27,10 @@ namespace D3D9on12
         void MarkInputLayoutAsDirty() { m_dirtyFlags.InputLayout = true; }
 
         D3D12_GRAPHICS_PIPELINE_STATE_DESC& CurrentPSODesc() { return m_PSODesc; }
+
+        void SetIntzRestoreZWrite(BOOL value) { m_intzRestoreZWrite = value; }
+        BOOL GetIntzRestoreZWrite() { return m_intzRestoreZWrite; }
+
     private:
         PipelineStateDirtyFlags     m_dirtyFlags;
 
@@ -56,5 +60,7 @@ namespace D3D9on12
         };
 
         D3D12_GRAPHICS_PIPELINE_STATE_DESC m_PSODesc;
+        
+        BOOL m_intzRestoreZWrite;
     };
 };

--- a/include/9on12draw.inl
+++ b/include/9on12draw.inl
@@ -47,6 +47,11 @@ namespace D3D9on12
     {
         // Data uploaded for a draw is only valid for that draw, and should be cleaned up immediately after to prevent
         // successive draws from reading stale/deleted data
+        if (device.GetPipelineState().GetIntzRestoreZWrite())
+        {
+            device.GetPipelineState().GetPixelStage().SetDepthStencilState(device, D3DRS_ZWRITEENABLE, 1);
+            device.GetPipelineState().SetIntzRestoreZWrite(false);
+        }
         device.GetSystemMemoryAllocator().ClearDeferredDestroyedResource();
         device.GetPipelineState().GetInputAssembly().ResetUploadBufferData();
         return S_OK;

--- a/src/9on12PipelineState.cpp
+++ b/src/9on12PipelineState.cpp
@@ -408,7 +408,8 @@ namespace D3D9on12
         m_inputAssembly(m_dirtyFlags, m_rasterStates),
         m_vertexStage(device, m_dirtyFlags, m_rasterStates),
         m_pixelStage(m_dirtyFlags, m_rasterStates),
-        m_bNeedsPipelineState(false)
+        m_bNeedsPipelineState(false),
+        m_intzRestoreZWrite(false)
     {
         memset(&m_PSODesc, 0, sizeof(m_PSODesc));
 

--- a/src/9on12PixelStage.cpp
+++ b/src/9on12PixelStage.cpp
@@ -885,10 +885,19 @@ namespace D3D9on12
                     D3D12TranslationLayer::SRV* pSRV = nullptr;
                     Resource* pResource = m_shaderResources[i];
                     if (pResource)
-                    {
+                    {   
                         // Certain apps expect the driver to automatically unbind resources as SRVs when they are bound as RTVs
                         // Examples inclue Alan Wake and Valkyrie Chronicles
                         bool HideSRV = pResource->GetDSVBindingTracker().IsBound() && GetDepthStencilStateID().ZWriteEnable;
+
+                        // resources with INTZ surface format, set ZWriteEnable to false instead of hiding SRV
+                        if (HideSRV && (pResource->GetD3DFormat() == D3DFMT_INTZ))
+                        {
+                            HideSRV = false;
+                            SetDepthStencilState(device, D3DRS_ZWRITEENABLE, 0);
+                            device.GetPipelineState().SetIntzRestoreZWrite(true);
+                        }
+
                         if (!HideSRV && pResource->GetRTVBindingTracker().IsBound())
                         {
                             HideSRV = true;


### PR DESCRIPTION
Cities used INTZ surface to read in the shader that rendered the water patches to
calculate depth from water surface to the backing z surface. Cities
bound the INTZ as SRV and kept the same INTZ surface bound for depth
testing and the depth writes enabled. Dx9on12 checked for SRV resource
being bound for DSV and ZWriteEnable in ResolveDeferredState() from
9on12PixelStage.cpp, the combination would cause the resource to be
unbound. Dx9on12 was doing the right thing, it should be application's
responsibility to remove the SRV.

Reviewed upon INTZ documents, it appeared that when using INTZ as shader
resources and keeping it bound as depth required the ZWriteEnable to be
false. The proposed fix detected for INTZ resources bound as SRV and
DSV, instead of hiding SRV, disabled ZWriteEnable and
continued to bind the resource as SRV. At the end of drawcall, restored
ZWriteEnable state.