### PR TITLE
Updating default value for unbound shader inputs with D3DDECLUSAGE_COLOR

### DIFF
--- a/ShaderConverter/ShaderConv/context.hpp
+++ b/ShaderConverter/ShaderConv/context.hpp
@@ -520,6 +520,9 @@ protected:
                     switch (usage)
                     {
                     case D3DDECLUSAGE_COLOR:
+                        defaultValue = COperand(0.0f, 0.0f, 0.0f, 1.0f);
+                        break;
+
                     case D3DDECLUSAGE_PSIZE:
                         defaultValue = COperand(1.0f);
                         break;


### PR DESCRIPTION
Updating default Value for D3DDECLUSAGE_COLOR in the case of unbound shader inputs from (1.0f, 1.0f, 1.0f,1.0f) to (0.0f, 0.0f, 0.0f, 1.0f)