### PR TITLE
Omit ClipDistance PS input when added to the end of VS outputs

### DIFF
--- a/include/9on12Shader.h
+++ b/include/9on12Shader.h
@@ -291,7 +291,7 @@ namespace D3D9on12
         PixelShader(Device& parentDevice, _In_ CONST byte& byteCode, _In_ size_t byteCodeLength, WeakHash hash);
         ~PixelShader();
 
-        D3D12PixelShader& GetD3D12Shader(const ShaderConv::RasterStates &rasterStates, ShaderConv::VSOutputDecls& vsOutputDecls, D3D12Shader& inputShader);
+        D3D12PixelShader& GetD3D12Shader(ShaderConv::RasterStates rasterStates, const ShaderConv::VSOutputDecls& vsOutputDecls, D3D12Shader& inputShader);
 
     private:
 


### PR DESCRIPTION
Addresses some recompiles caused by changes to UserClipPlanes state. D3D9 has an API-level feature to control the number of user clip planes and their values. In DX10+, this feature is implemented using a system value shader output, `SV_ClipDistance`. To implement user clip planes, D3D9on12 generates a vertex shader that writes to `SV_ClipDistance`, but this also causes a recompile of the (otherwise unchanged) pixel shader which now has `SV_ClipDistance` as an input.