### PR TITLE
Initialize all RasterState sampler types to TEXTURETYPE_2D

### DIFF
--- a/ShaderConverter/Inc/ShaderConv.h
+++ b/ShaderConverter/Inc/ShaderConv.h
@@ -235,7 +235,10 @@ struct SamplerInfo
         };
     };
 
-    SamplerInfo() : Value( 0 )
+    // Initially set all texture types to TEXTURETYPE_2D - we can't go with TEXTURETYPE_UNKNOWN
+    // because the shader converter needs a valid texture type for the shader declaration, even
+    // when a null resource is bound.
+    SamplerInfo() : TextureType( TEXTURETYPE_2D ), TexCoordWrap( 0 )
     {
         C_ASSERT( sizeof( SamplerInfo ) == sizeof( Value ) );
     }


### PR DESCRIPTION
Occasionally we will see 9on12 generate two nearly-identical shaders for the same legacy PS, where the only difference is the unused 3rd and 4th coordinates on the sample location of a texture 2D sample. We'll see either e.g. `r9.xyzw` or `r9.xyyy`. The `r9.xyzw` variant is generated when 9on12 doesn't know that the texture is a Texture2D because no texture has ever been bound in that slot.

9on12 normally uses Texture2D as the default type (it sets to this mode when the texture slot is unbound) but it is not initialized this way, so the variant of shader we see depends on whether any previous draw call has bound a texture in that slot. With this fix, we initialize the mode in all slots to Texture2D so it matches later behavior when those slots have been used and then cleared.