### PR TITLE
Enable IsEquals() comparisons in 9on12PipelineStateStructures.h

### DIFF
--- a/include/9on12PipelineStateStructures.h
+++ b/include/9on12PipelineStateStructures.h
@@ -818,10 +818,13 @@ namespace D3D9on12
 
         // TODO: It's not immediately clear if the branching will more perf issues than it's worth,
         // Toggle this off and on when we're in a position to test perf
+
+        // Enabling this function by default, after finding significant performance improvement in some cases (CS:GO);
+        // The cost of branching does not appear to be greater than the cost of marking dirty flags every time we Set
         template<typename T>
         FORCEINLINE bool IsEquals(T objA, T objB)
         {
-#if 0
+#if 1
             return objA == objB;
 #else
             // The compiler should be smart enough to tell that this means no branching is needed

--- a/include/9on12PipelineStateStructures.h
+++ b/include/9on12PipelineStateStructures.h
@@ -816,22 +816,10 @@ namespace D3D9on12
         {
         }
 
-        // TODO: It's not immediately clear if the branching will more perf issues than it's worth,
-        // Toggle this off and on when we're in a position to test perf
-
-        // Enabling this function by default, after finding significant performance improvement in some cases (CS:GO);
-        // The cost of branching does not appear to be greater than the cost of marking dirty flags every time we Set
         template<typename T>
         FORCEINLINE bool IsEquals(T objA, T objB)
         {
-#if 1
             return objA == objB;
-#else
-            // The compiler should be smart enough to tell that this means no branching is needed
-            UNREFERENCED_PARAMETER(objA);
-            UNREFERENCED_PARAMETER(objB);
-            return 0;
-#endif
         }
     };
 


### PR DESCRIPTION
IsEquals() is disabled by default, which results in a lot of dirty flags being marked without checking for values already set.

Profiled the adjustment on CS:GO and observed ~6-7% performance gain.