### PR TITLE
Fix how we determine if we are drawing pretransformed verts

### DIFF
--- a/include/9on12Device.h
+++ b/include/9on12Device.h
@@ -163,8 +163,6 @@ namespace D3D9on12
         BYTE m_pVideoDeviceSpace[sizeof(VideoDevice)];
         VideoDevice *m_pVideoDevice;
 
-        bool m_drawingPreTransformedVerts = false;
-
         //This should be cleared before each use. we're just saving the allocation
         std::vector<D3D12TranslationLayer::PresentSurface> m_d3d12tlPresentSurfaces;
         //This should be cleared before each use. we're just saving the allocation

--- a/include/9on12draw.inl
+++ b/include/9on12draw.inl
@@ -69,7 +69,6 @@ namespace D3D9on12
             RETURN_E_INVALIDARG_AND_CHECK();
         }
 
-        pDevice->SetDrawingPreTransformedVerts(false);
         OffsetArg baseVertexOffset = OffsetArg::AsOffsetInVertices(pDrawPrimitiveArg->VStart);
         OffsetArg baseIndexOffset = OffsetArg::AsOffsetInIndices(0);
 
@@ -123,7 +122,6 @@ namespace D3D9on12
         UINT const stream0Stride = pDevice->GetPipelineState().GetInputAssembly().GetStream0Stride();
         Check9on12(stream0Stride > 0);
 
-        pDevice->SetDrawingPreTransformedVerts(true);
         OffsetArg baseVertexOffset = OffsetArg::AsOffsetInBytes(pDrawPrimitiveArg->FirstVertexOffset);
         OffsetArg baseIndexOffset = OffsetArg::AsOffsetInIndices(0);
 
@@ -173,7 +171,6 @@ namespace D3D9on12
         UINT const stream0Stride = pDevice->GetPipelineState().GetInputAssembly().GetStream0Stride();
         Check9on12(stream0Stride > 0);
 
-        pDevice->SetDrawingPreTransformedVerts(true);
         bool bNegativeVertexOffset = pData->BaseVertexOffset < 0;
         OffsetArg baseVertexOffset = OffsetArg::AsOffsetInBytes(pData->BaseVertexOffset);
         OffsetArg drawOffset = OffsetArg::AsOffsetInVertices(0);
@@ -476,7 +473,6 @@ namespace D3D9on12
         UINT StartInstanceLocation = 0;
         const UINT vertexCount = pDrawPrimitiveArg->MinIndex + pDrawPrimitiveArg->NumVertices;
 
-        pDevice->SetDrawingPreTransformedVerts(false);
         OffsetArg baseIndexOffset = OffsetArg::AsOffsetInIndices(pDrawPrimitiveArg->StartIndex);
         OffsetArg baseVertexOffset = OffsetArg::AsOffsetInVertices(pDrawPrimitiveArg->BaseVertexIndex);
 

--- a/src/9on12Device.cpp
+++ b/src/9on12Device.cpp
@@ -622,9 +622,6 @@ namespace D3D9on12
 
     void Device::SetDrawingPreTransformedVerts(bool preTransformedVerts)
     {
-        if (preTransformedVerts != m_drawingPreTransformedVerts)
-        {
-            GetPipelineState().GetPixelStage().SetPreTransformedVertexMode(preTransformedVerts);
-        }
+        GetPipelineState().GetPixelStage().SetPreTransformedVertexMode(preTransformedVerts);
     }
 };

--- a/src/9on12VertexStage.cpp
+++ b/src/9on12VertexStage.cpp
@@ -253,6 +253,7 @@ namespace D3D9on12
         {
             if (inputLayout.VerticesArePreTransformed())
             {
+                device.SetDrawingPreTransformedVerts(true);
                 m_pCurrentD3D12VS = &m_tlShaderCache.GetD3D12ShaderForTL(inputLayout, m_rasterStates.GetRasterState());
 
                 psoDesc.VS = m_pCurrentD3D12VS->GetUnderlying()->GetByteCode();
@@ -261,6 +262,7 @@ namespace D3D9on12
             }
             else
             {
+                device.SetDrawingPreTransformedVerts(false);
                 m_pCurrentD3D12VS = &m_pCurrentVS->GetD3D12Shader(m_rasterStates.GetRasterState(), inputLayout);
 
                 psoDesc.VS = m_pCurrentD3D12VS->GetUnderlying()->GetByteCode();


### PR DESCRIPTION
The correct way to determine if we are drawing pre transformed verts is by checking if the d3ddeclusage is positionT, not based off of which Draw API is being used.

https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics

Fixes #57 