### PR TITLE
Minor perf improvements + update for residency re-work

### DIFF
--- a/include/9on12Registry.h
+++ b/include/9on12Registry.h
@@ -23,7 +23,6 @@ namespace D3D9on12
         static const LPCSTR g_cValidateShaders = "ValidateShaders";
         static const LPCSTR g_cSingleThread = "Singlethread";
         static const LPCSTR g_cPresentWithDummyWindow = "PresentWithDummyWindow";
-        static const LPCSTR g_cDisableMemoryManagement = "DisableResidencyManagement";
         static const LPCSTR g_cAnythingTimes0Equals0 = "AnythingTimes0Equals0";
         static const LPCSTR g_cPSOCacheTrimLimitSize = "PSOCacheTrimLimitSize";
         static const LPCSTR g_cPSOCacheTrimLimitAge = "PSOCacheTrimLimitAge";
@@ -100,7 +99,6 @@ namespace D3D9on12
         static const bool g_cUseDebugLayer = CheckRegistryKey(RegistryKeys::g_cDebugLayerEnabledKey);
         static const bool g_cBreakOnLoad = CheckRegistryKey(RegistryKeys::g_cBreakOnLoadKey);
         static const bool g_cSingleThread = CheckRegistryKey(RegistryKeys::g_cSingleThread);  
-        static const bool g_cDisableMemoryManagement = CheckRegistryKey(RegistryKeys::g_cDisableMemoryManagement);
         static const DWORD g_cPSOCacheTrimLimitSize = CheckRegistryKeyDWORD(RegistryKeys::g_cPSOCacheTrimLimitSize, MAXDWORD);
         static const DWORD g_cPSOCacheTrimLimitAge = CheckRegistryKeyDWORD(RegistryKeys::g_cPSOCacheTrimLimitAge, MAXDWORD);
         static const DWORD g_cMaxAllocatedUploadHeapSpacePerCommandList = CheckRegistryKeyDWORD(RegistryKeys::g_cMaxAllocatedUploadHeapSpacePerCommandList, MAXDWORD);

--- a/src/9on12Device.cpp
+++ b/src/9on12Device.cpp
@@ -297,7 +297,7 @@ namespace D3D9on12
         Device* pDevice = p9on12Resource->GetParent();
         auto& ImmCtx = pDevice->GetContext();
 
-        if (ImmCtx.IsResidencyManagementEnabled() && pResidencyHandle)
+        if (pResidencyHandle)
         {
             // Pin the resource while it is checked out to the caller.
             pResidencyHandle->Pin();
@@ -364,7 +364,7 @@ namespace D3D9on12
 
         pTranslationLayerResource->AddDeferredWaits(DeferredWaits);
 
-        if (ImmCtx.IsResidencyManagementEnabled() && pResidencyHandle)
+        if (pResidencyHandle)
         {
             // Transition from an explicit pin to a pin until these waits are satisfied.
             pResidencyHandle->AddPinWaits(NumSync, pSignalValues, ppFences);
@@ -474,7 +474,7 @@ namespace D3D9on12
             args.RenamingIsMultithreaded = args.CreatesAndDestroysAreMultithreaded;
             args.UseThreadpoolForPSOCreates = false;
             args.UseRoundTripPSOs = false;
-            args.UseResidencyManagement = !RegistryConstants::g_cDisableMemoryManagement;
+            args.UseResidencyManagement = true;
             args.DisableGPUTimeout = false;
             args.AdjustYUY2BlitCoords = m_Adapter.RequiresYUY2BlitWorkaround();
 #ifdef __D3D9On12CreatorID_INTERFACE_DEFINED__

--- a/src/9on12PipelineStateCache.cpp
+++ b/src/9on12PipelineStateCache.cpp
@@ -26,8 +26,7 @@ namespace D3D9on12
         {
             std::shared_ptr<PipelineStateCacheEntry>& cacheEntry = it->second;
             assert(cacheEntry.get() == cacheEntry->m_accessOrderPos->get());
-            m_cache.m_accessOrder.erase(cacheEntry->m_accessOrderPos);
-            m_cache.m_accessOrder.emplace_front(cacheEntry);
+            m_cache.m_accessOrder.splice(m_cache.m_accessOrder.begin(), m_cache.m_accessOrder, cacheEntry->m_accessOrderPos);
             cacheEntry->m_accessOrderPos = m_cache.m_accessOrder.begin();
             cacheEntry->m_timestamp = timestamp;
             return cacheEntry->m_pPipelineState.get();

--- a/src/9on12Resource.cpp
+++ b/src/9on12Resource.cpp
@@ -1024,7 +1024,12 @@ namespace D3D9on12
             }
 
             const D3D12TranslationLayer::RESOURCE_USAGE UsageFlag = GetResourceUsage(createArgs.Flags, m_CpuAccessFlags);
-            const D3D12_HEAP_TYPE HeapType = D3D12TranslationLayer::Resource::GetD3D12HeapType(UsageFlag, m_CpuAccessFlags);
+            D3D12_HEAP_TYPE HeapType = D3D12TranslationLayer::Resource::GetD3D12HeapType(UsageFlag, m_CpuAccessFlags);
+            if (HeapType == D3D12_HEAP_TYPE_UPLOAD && (createArgs.Flags.VertexBuffer || createArgs.Flags.IndexBuffer) &&
+                createArgs.Flags.HintStatic)
+            {
+                HeapType = D3D12_HEAP_TYPE_DEFAULT;
+            }
 
             m_TranslationLayerCreateArgs.m_desc12 = m_desc;
             m_TranslationLayerCreateArgs.m_appDesc = ConvertToAppResourceDesc(m_desc,

--- a/src/9on12Resource.cpp
+++ b/src/9on12Resource.cpp
@@ -1315,7 +1315,7 @@ namespace D3D9on12
         // In the async case, we need to make sure that we don't touch m_pResource's identity,
         // as this could be changing out from under us. However, m_pResource is safe to query
         // information from. Instead of using m_pResource's identity, use m_LastRenamedResource.
-        D3D12TranslationLayer::SafeRenameResourceCookie pCookieProtector(device.GetContext());
+        D3D12TranslationLayer::SafeRenameResourceCookie pCookieProtector;
         if (bAsyncLock)
         {
             // TODO: (11369816) Not supporting lock async with non-buffers or CPU readable resources


### PR DESCRIPTION
Remove some unneeded CPU allocations from the PSO LRU cache by using `splice` instead of freeing and reallocating list nodes, and deal with the residency re-work from https://github.com/microsoft/D3D12TranslationLayer/pull/80.