### PR TITLE
Fix SetPrimitiveType comparison

### DIFF
--- a/include/9on12PipelineStateStructures.h
+++ b/include/9on12PipelineStateStructures.h
@@ -564,7 +564,7 @@ namespace D3D9on12
 
         void SetPrimitiveType(D3DPRIMITIVETYPE inPrimitiveType)
         {
-            if (!IsEquals(inPrimitiveType, inPrimitiveType))
+            if (!IsEquals((D3DPRIMITIVETYPE)PrimitiveType, inPrimitiveType))
             {
                 PrimitiveType = inPrimitiveType;
                 MarkGSDirty();


### PR DESCRIPTION
Looks like we had a typo in a comparison that was never caught since the `IsEquals` function was `#if`'d to always return false.
Brought to light by #50 