### PR TITLE
Validate render/sampler state values, avoiding integer bitfield overflow

### DIFF
--- a/src/9on12PipelineState.cpp
+++ b/src/9on12PipelineState.cpp
@@ -281,6 +281,20 @@ namespace D3D9on12
             return;
         }
 
+        // check for integer bitfield overflow causing issues with some apps submitting invalid
+        // sampler state values. 
+        if ((dwState == D3DTSS_MAGFILTER && dwValue >= 16u) ||
+            (dwState == D3DTSS_MINFILTER && dwValue >= 16u) ||
+            (dwState == D3DTSS_MIPFILTER && dwValue >= 16u) ||
+            (dwState == D3DTSS_ADDRESSU && dwValue >= 8u) ||
+            (dwState == D3DTSS_ADDRESSV && dwValue >= 8u) ||
+            (dwState == D3DTSS_ADDRESSW && dwValue >= 8u) ||
+            (dwState == D3DTSS_MAXANISOTROPY && dwValue >= 256u))
+        {
+	        Check9on12(false);
+            return;
+        }
+
         m_dwTextureStageStates[dwStage][dwState] = dwValue;
 
         SamplerStateID& samplerID = m_pixelStage.GetSamplerID(dwStage);

--- a/src/9on12PixelStage.cpp
+++ b/src/9on12PixelStage.cpp
@@ -335,14 +335,17 @@ namespace D3D9on12
             m_dirtyFlags.RasterizerState = true;
             break;
         case D3DRS_MULTISAMPLEANTIALIAS:
+            if (dwValue >= 2u) dwValue = TRUE;
             m_rasterizerStateID.MultiSampleAntiAlias = dwValue;
             m_dirtyFlags.RasterizerState = true;
             break;
         case D3DRS_ANTIALIASEDLINEENABLE:
+            if (dwValue >= 2u) dwValue = TRUE;
             m_rasterizerStateID.AntialiasedLineEnable = dwValue;
             m_dirtyFlags.RasterizerState = true;
             break;
         case D3DRS_CLIPPING:
+            if (dwValue >= 2u) dwValue = TRUE;
             m_rasterizerStateID.DepthClipEnable = dwValue;
             m_dirtyFlags.RasterizerState = true;
             break;
@@ -474,18 +477,22 @@ namespace D3D9on12
         {
             // Blend states  
         case D3DRS_ALPHABLENDENABLE:
+            if (dwValue >= 2) dwValue = TRUE;
             m_blendStateID.AlphaBlendEnable = dwValue;
             m_dirtyFlags.BlendState = true;
             break;
         case D3DRS_SRCBLEND:
+            if (dwValue >= 32) dwValue = D3DBLEND_ONE;
             m_blendStateID.SrcBlend = dwValue;
             m_dirtyFlags.BlendState = true;
             break;
         case D3DRS_DESTBLEND:
+            if (dwValue >= 32) dwValue = D3DBLEND_ZERO;
             m_blendStateID.DstBlend = dwValue;
             m_dirtyFlags.BlendState = true;
             break;
         case D3DRS_BLENDOP:
+            if (dwValue >= 8) dwValue = D3DBLENDOP_ADD;
             m_blendStateID.BlendOp = dwValue;
             m_dirtyFlags.BlendState = true;
             break;
@@ -498,21 +505,24 @@ namespace D3D9on12
             }
             break;
         case D3DRS_SEPARATEALPHABLENDENABLE:
+            if (dwValue >= 2) dwValue = TRUE;
             m_blendStateID.SeparateAlphaBlend = dwValue;
             m_dirtyFlags.BlendState = true;
             break;
         case D3DRS_SRCBLENDALPHA:
+            if (dwValue >= 32) dwValue = D3DBLEND_ONE;
             m_blendStateID.SrcBlendAlpha = dwValue;
             m_dirtyFlags.BlendState = true;
             break;
         case D3DRS_DESTBLENDALPHA:
+            if (dwValue >= 32) dwValue = D3DBLEND_ZERO;
             m_blendStateID.DstBlendAlpha = dwValue;
             m_dirtyFlags.BlendState = true;
             break;
         case D3DRS_BLENDOPALPHA:
             assert(dwValue <= D3DBLENDOP_MAX);
             // Assuming the app is asking for "default" behavior
-            if (dwValue == 0)
+            if (dwValue == 0 || dwValue > D3DBLENDOP_MAX)
             {
                 dwValue = D3DBLENDOP_ADD;
             }


### PR DESCRIPTION
A fix that adds validation for render/sampler state values, avoiding integer bitfield overflow, which caused issues with some apps passing invalid values to the render states.

A minimal reproducible example you can build yourself: https://gist.github.com/usernameak/bda2ad123c524442f36d68fc2881c6fb