### PR TITLE
Support aniso with mip point

### DIFF
--- a/include/9on12Device.h
+++ b/include/9on12Device.h
@@ -109,6 +109,8 @@ namespace D3D9on12
         ShaderDedupe<VertexShader> m_VSDedupe;
         ShaderDedupe<PixelShader> m_PSDedupe;
 
+        D3D12_FEATURE_DATA_D3D12_OPTIONS19 m_Options19;
+
         D3D12TranslationLayer::COptLockedContainer<std::unordered_map<Resource*, std::vector<LockRange>>> m_lockedResourceRanges;
         void SetDrawingPreTransformedVerts(bool preTransformedVerts);
 

--- a/include/9on12PipelineStateStructures.h
+++ b/include/9on12PipelineStateStructures.h
@@ -477,7 +477,7 @@ namespace D3D9on12
         return depthStencilDesc;
     }
 
-    static D3D12_SAMPLER_DESC ConvertSampler(SamplerStateID samplerID)
+    static D3D12_SAMPLER_DESC ConvertSampler(SamplerStateID samplerID, bool supportAnisoPointMip)
     {
         D3D12_SAMPLER_DESC samplerDesc = {};
         samplerDesc.MinLOD = static_cast<float>(samplerID.MaxMipLevel);
@@ -487,7 +487,8 @@ namespace D3D9on12
             static_cast<D3DTEXTUREFILTERTYPE>(samplerID.MagFilter),
             static_cast<D3DTEXTUREFILTERTYPE>(samplerID.MinFilter),
             static_cast<D3DTEXTUREFILTERTYPE>(samplerID.MipFilter),
-            samplerID.UseHardwareShadowMapping);
+            samplerID.UseHardwareShadowMapping,
+            supportAnisoPointMip);
 
         samplerDesc.AddressU = ConvertToD3D12TextureAddress(static_cast<D3DTEXTUREADDRESS>(samplerID.AddressU));
         samplerDesc.AddressV = ConvertToD3D12TextureAddress(static_cast<D3DTEXTUREADDRESS>(samplerID.AddressV));

--- a/include/9on12Util.h
+++ b/include/9on12Util.h
@@ -634,6 +634,8 @@ __pragma(warning(suppress:4127)) /* conditional is constant due to constant macr
                 return D3D12_FILTER_COMPARISON_MIN_MAG_MIP_LINEAR;
             case D3D12_FILTER_ANISOTROPIC                    :
                 return D3D12_FILTER_COMPARISON_ANISOTROPIC;
+            case D3D12_FILTER_MIN_MAG_ANISOTROPIC_MIP_POINT  :
+                return D3D12_FILTER_COMPARISON_MIN_MAG_ANISOTROPIC_MIP_POINT;
             default:
                 Check9on12(false);
                 return (D3D12_FILTER)-1;
@@ -643,12 +645,15 @@ __pragma(warning(suppress:4127)) /* conditional is constant due to constant macr
     static D3D12_FILTER ConvertToD3D12Filter(
         D3DTEXTUREFILTERTYPE magFilter,
         D3DTEXTUREFILTERTYPE minFilter,
-        D3DTEXTUREFILTERTYPE mipFilter)
+        D3DTEXTUREFILTERTYPE mipFilter,
+        bool supportAnisoPointMip)
     {
         if ((D3DTEXF_ANISOTROPIC == minFilter)
             || (D3DTEXF_ANISOTROPIC == magFilter))
         {
-            return D3D12_FILTER_ANISOTROPIC;
+            return (mipFilter == D3DTEXF_POINT && supportAnisoPointMip) ?
+                D3D12_FILTER_MIN_MAG_ANISOTROPIC_MIP_POINT :
+                D3D12_FILTER_ANISOTROPIC;
         }
         switch (mipFilter)
         {
@@ -717,9 +722,10 @@ __pragma(warning(suppress:4127)) /* conditional is constant due to constant macr
         D3DTEXTUREFILTERTYPE magFilter,
         D3DTEXTUREFILTERTYPE minFilter,
         D3DTEXTUREFILTERTYPE mipFilter,
-        bool comparisonEnabled)
+        bool comparisonEnabled,
+        bool supportAnisoPointMip)
     {
-        D3D12_FILTER filter = ConvertToD3D12Filter(magFilter, minFilter, mipFilter);
+        D3D12_FILTER filter = ConvertToD3D12Filter(magFilter, minFilter, mipFilter, supportAnisoPointMip);
         if (comparisonEnabled)
         {
             filter = ConvertToD3D12ComparisonFilter(filter);

--- a/src/9on12Device.cpp
+++ b/src/9on12Device.cpp
@@ -519,6 +519,8 @@ namespace D3D9on12
         {
             m_Adapter.DeviceCreated(this);
         }
+
+        (void)GetDevice().CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS19, &m_Options19, sizeof(m_Options19));
         return hr;
     }
 

--- a/src/9on12PixelStage.cpp
+++ b/src/9on12PixelStage.cpp
@@ -996,7 +996,7 @@ namespace D3D9on12
         auto result = m_map.find(id);
         if (result == m_map.end())
         {
-            D3D12_SAMPLER_DESC createSamplerDesc = ConvertSampler(id);
+            D3D12_SAMPLER_DESC createSamplerDesc = ConvertSampler(id, device.m_Options19.AnisoFilterWithPointMipSupported);
 
             m_map[id] = std::unique_ptr<D3D12TranslationLayer::Sampler>(new D3D12TranslationLayer::Sampler(&device.GetContext(), createSamplerDesc));
 


### PR DESCRIPTION
This is a new feature in D3D12, but an old feature for D3D9. Requires https://github.com/microsoft/D3D12TranslationLayer/pull/88 to merge first.