### PR TITLE
Add Dirty Flag for Extension Constants Binding

### DIFF
--- a/include/9on12Constants.h
+++ b/include/9on12Constants.h
@@ -156,6 +156,7 @@ namespace D3D9on12
             void Destroy();
 
             ConstantBufferBinding m_extension;
+            bool m_dirty = true;
         };
 
         struct GeometryShaderConstants
@@ -166,6 +167,7 @@ namespace D3D9on12
             void Destroy();
 
             ConstantBufferBinding m_extension;
+            bool m_dirty = true;
         };
 
         struct PixelShaderConstants : public StageConstants
@@ -180,6 +182,8 @@ namespace D3D9on12
             ConstantBufferBinding m_extension1;
             ConstantBufferBinding m_extension2;
             ConstantBufferBinding m_extension3;
+
+            bool m_dirty = true;
         };
 
     public:

--- a/src/9on12Constants.cpp
+++ b/src/9on12Constants.cpp
@@ -210,22 +210,38 @@ namespace D3D9on12
 
         //Bind Internal Extension Constants (used by the Shader Converter)
         {
-            BindToPipeline(m_device, m_vertexShaderData.m_extension, D3D12TranslationLayer::EShaderStage::e_VS);
-            BindToPipeline(m_device, m_geometryShaderData.m_extension, D3D12TranslationLayer::EShaderStage::e_GS);
-            BindToPipeline(m_device, m_pixelShaderData.m_extension1, D3D12TranslationLayer::EShaderStage::e_PS);
-            BindToPipeline(m_device, m_pixelShaderData.m_extension2, D3D12TranslationLayer::EShaderStage::e_PS);
-            BindToPipeline(m_device, m_pixelShaderData.m_extension3, D3D12TranslationLayer::EShaderStage::e_PS);
+            if (m_vertexShaderData.m_dirty)
+            {
+                BindToPipeline(m_device, m_vertexShaderData.m_extension, D3D12TranslationLayer::EShaderStage::e_VS);
+                m_vertexShaderData.m_dirty = false;
+            }
+
+            if (m_geometryShaderData.m_dirty)
+            {
+                BindToPipeline(m_device, m_geometryShaderData.m_extension, D3D12TranslationLayer::EShaderStage::e_GS);
+                m_geometryShaderData.m_dirty = false;
+            }
+
+            if (m_pixelShaderData.m_dirty)
+            {
+                BindToPipeline(m_device, m_pixelShaderData.m_extension1, D3D12TranslationLayer::EShaderStage::e_PS);
+                BindToPipeline(m_device, m_pixelShaderData.m_extension2, D3D12TranslationLayer::EShaderStage::e_PS);
+                BindToPipeline(m_device, m_pixelShaderData.m_extension3, D3D12TranslationLayer::EShaderStage::e_PS);
+                m_pixelShaderData.m_dirty = false;
+            }
         }
     }
 
     void ConstantsManager::UpdateVertexShaderExtension(const ShaderConv::VSCBExtension& data)
     {
         m_vertexShaderData.m_extension.Version(&data, sizeof(data));
+        m_vertexShaderData.m_dirty = true;
     }
 
     void ConstantsManager::UpdateGeometryShaderExtension(const ShaderConv::VSCBExtension& data)
     {
         m_geometryShaderData.m_extension.Version(&data, sizeof(data));
+        m_geometryShaderData.m_dirty = true;
     }
 
     Result ConstantsManager::UpdatePixelShaderExtension(const ShaderConv::eConstantBuffers extension, const void* pData, size_t dataSize)
@@ -249,6 +265,8 @@ namespace D3D9on12
         }
         assert(dataSize <= UINT_MAX);
         pBinding->Version(pData, static_cast<UINT>(dataSize));
+
+        m_pixelShaderData.m_dirty = true;
 
         return Result::S_SUCCESS;
     }


### PR DESCRIPTION
The code unconditionally calls BindToPipeline() for the internal extension constants (e.g. m_vertexShader.m_extension), even when the extension data remains the same, and this is a significant cost per draw call.

This change adds a dirty flag to each extension constant so that we only call BindToPipeline() when the data changes.

Testing on CS:GO's Dust II map, the frame rate improves from around 270 to around 285.