### PR TITLE
Update memcpy for InputBuffer::Upload to limit size of copy to a valid data range

### DIFF
--- a/src/9on12InputAssembly.cpp
+++ b/src/9on12InputAssembly.cpp
@@ -190,7 +190,8 @@ namespace D3D9on12
 
         m_tempGPUBuffer = device.GetSystemMemoryAllocator().Allocate(drawOffset + drawSize);
 
-        memcpy((byte*)m_tempGPUBuffer.m_pMappedAddress + drawOffset, (byte*)GetSystemMemoryBase() + drawOffset, drawSize);
+        UINT32 maxCopySize = m_sizeInBytes - drawOffset;
+        memcpy((byte*)m_tempGPUBuffer.m_pMappedAddress + drawOffset, (byte*)GetSystemMemoryBase() + drawOffset, min(drawSize, maxCopySize));
 
         return S_OK;
     }


### PR DESCRIPTION
We've seen at least one app that appears to be passing too high of a vertex count. This should guard against reading out of bounds.