### PR TITLE
Change InputBuffer::m_sizeInBytes default to UINT32_MAX

### DIFF
--- a/include/9on12InputAssembly.h
+++ b/include/9on12InputAssembly.h
@@ -40,7 +40,9 @@ namespace D3D9on12
 
         UINT m_bufferStride = 0;
         UINT m_bufferOffset = 0;
-        UINT m_sizeInBytes = 0;
+        // Only used for bounds checking in Upload() when possible. This default may not make sense if that changes.
+        // Primarily a risk due to InputAssembly::Set*BufferUM not knowing buffer size.
+        UINT m_sizeInBytes = UINT32_MAX;
     };
 
     class InputAssembly


### PR DESCRIPTION
m_sizeInBytes is only used for bounds checking, but we don't always have a valid size to go off of, particularly for user memory buffers.

When possible, we will take advantage of it for the bounds check, but if it isn't available we should default to trusting the app to pass valid data. UINT32_MAX will always be greater than the attempted upload size, so this is a safe default in this case.