### PR TITLE
[Translate_RCP] Handle modifiers on src0 before performing movc

### DIFF
--- a/ShaderConverter/ShaderConv/context.cpp
+++ b/ShaderConverter/ShaderConv/context.cpp
@@ -1523,7 +1523,8 @@ CContext::Translate_RCP( const CInstr& instr )
     if ( dwModifier != D3DSPSM_NONE ) 
     {
         // mov  r0.z, src0
-        // movc dest, src0, dest, src0
+        // movc dest, r0.z, dest, src0
+
 
         m_pShaderAsm->EmitInstruction(
             CInstruction( D3D10_SB_OPCODE_MOV,

--- a/ShaderConverter/ShaderConv/context.cpp
+++ b/ShaderConverter/ShaderConv/context.cpp
@@ -1518,10 +1518,12 @@ CContext::Translate_RCP( const CInstr& instr )
                               COperand( 1.0f ),
                               src0 );
 
-    if ( dwModifier != D3DSPSM_NONE )
+    // movc doesn't allow modifiers on the comparison param, so if src0 has modifiers we need to apply those and mov into a temp register
+    // note that according to spec, rcp can only act on scalar values, so we just mov into r0.z
+    if ( dwModifier != D3DSPSM_NONE ) 
     {
-        // mov  s0.z, src0
-        // movc dest, src0, dest, vec4( FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX )
+        // mov  r0.z, src0
+        // movc dest, src0, dest, src0
 
         m_pShaderAsm->EmitInstruction(
             CInstruction( D3D10_SB_OPCODE_MOV,
@@ -1533,18 +1535,18 @@ CContext::Translate_RCP( const CInstr& instr )
                                   dest,
                                   CTempOperand4( SREG_TMP0, __SWIZZLE_Z ),
                                   dest,
-                                  COperand( FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX ) );
+                                  src0 );
     }
     else
     {
-        // movc dest, src0, dest, vec4( FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX )
+        // movc dest, src0, dest, src0
 
         this->EmitDstInstruction( instr.GetModifiers(),
                                   D3D10_SB_OPCODE_MOVC,
                                   dest,
                                   src0,
                                   dest,
-                                  COperand( FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX ) );
+                                  src0 );
     }
 }
 


### PR DESCRIPTION
The rcp instruction is allowed to have modifiers on src0, such as `_abs`. When we perform the translation, src0 gets passed as the comparison param for movc, which is [not allowed to have modifiers](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/movc--sm4---asm-). When we detect that src0 has modifiers present, we need to handle that by doign a mov into a temp register. This was actually done in #51 , but when CSGO was found to have rendering issues after the changes the movc fix got reverted too (#55 ). 

This PR brings back the movc fixes from those earlier PRs, but doesn't pick up the change to use FLT_MAX.

This is technically not to spec, as we should be using FLT_MAX here.
However, since CSGO (d3d9 version) was found to expect non-FLT_MAX
values when doing an rcp of 0, we're going to keep the out of spec
approach in case other apps have the same expectation.