### PR TITLE
Add regkey and compat shim options for bufferPoolTrimThreshold

### DIFF
--- a/include/9on12Registry.h
+++ b/include/9on12Registry.h
@@ -28,6 +28,7 @@ namespace D3D9on12
         static const LPCSTR g_cPSOCacheTrimLimitAge = "PSOCacheTrimLimitAge";
         static const LPCSTR g_cMaxAllocatedUploadHeapSpacePerCommandList = "MaxAllocatedUploadHeapSpacePerCommandList";
         static const LPCSTR g_cMaxSRVHeapSize = "MaxSRVHeapSize";
+        static const LPCSTR g_cBufferPoolTrimThreshold = "BufferPoolTrimThreshold"; // Must be in the range 5-100 to be used by the translation layer. If there is a compat shim, will take the lesser of the two values
         static const LPCSTR g_cLockDiscardOptimization = "LockDiscardOptimization";
     };
 
@@ -103,6 +104,7 @@ namespace D3D9on12
         static const DWORD g_cPSOCacheTrimLimitAge = CheckRegistryKeyDWORD(RegistryKeys::g_cPSOCacheTrimLimitAge, MAXDWORD);
         static const DWORD g_cMaxAllocatedUploadHeapSpacePerCommandList = CheckRegistryKeyDWORD(RegistryKeys::g_cMaxAllocatedUploadHeapSpacePerCommandList, MAXDWORD);
         static const DWORD g_cMaxSRVHeapSize = CheckRegistryKeyDWORD(RegistryKeys::g_cMaxSRVHeapSize, MAXDWORD);
+        static const DWORD g_cBufferPoolTrimThreshold = CheckRegistryKeyDWORD(RegistryKeys::g_cBufferPoolTrimThreshold, MAXDWORD);
         static const bool g_cLockDiscardOptimization = CheckRegistryKeyDWORD(RegistryKeys::g_cLockDiscardOptimization, 1);
     };
 };

--- a/interface/d3d9on12ddi.h
+++ b/interface/d3d9on12ddi.h
@@ -286,6 +286,7 @@ typedef struct _D3D9ON12_APP_COMPAT_INFO
     DWORD PSOCacheTrimLimitAge;   // We will only trim PSOs that are older then this age (age in command list age)
     DWORD MaxAllocatedUploadHeapSpacePerCommandList; // Maximum amount of storage allocated for upload operations per command list before flush
     DWORD MaxSRVHeapSize; // Maximum number of entries in the sharer resource view decriptor heap
+    DWORD BufferPoolTrimThreshold; // How many fences (roughly translates to frames) a buffer in the buffer pool is allowed to exist before it is eleigible for being reclaimed. Must be in the range 5-100 to have an effect
 } D3D9ON12_APP_COMPAT_INFO;
 
 typedef void (APIENTRY *PFND3D9ON12_SETAPPCOMPATDATA)(

--- a/src/9on12AppCompat.cpp
+++ b/src/9on12AppCompat.cpp
@@ -11,6 +11,7 @@ namespace D3D9on12
         MAXDWORD, // PSOCacheTrimLimitAge
         MAXDWORD, // MaxAllocatedUploadHeapSpacePerCommandList
         MAXDWORD, // MaxSRVHeapSize
+        MAXDWORD, // BufferPoolTrimThreshold
     };
 
     void APIENTRY SetAppCompatData(const D3D9ON12_APP_COMPAT_INFO *pAppCompatData)

--- a/src/9on12Device.cpp
+++ b/src/9on12Device.cpp
@@ -484,6 +484,7 @@ namespace D3D9on12
                     g_AppCompatInfo.MaxAllocatedUploadHeapSpacePerCommandList);
 
             args.MaxSRVHeapSize = min(RegistryConstants::g_cMaxSRVHeapSize, g_AppCompatInfo.MaxSRVHeapSize);
+            args.BufferPoolTrimThreshold = min(RegistryConstants::g_cBufferPoolTrimThreshold, g_AppCompatInfo.BufferPoolTrimThreshold);
 
             if (!RegistryConstants::g_cSingleThread)
             {


### PR DESCRIPTION
This is a useful workaround for apps that run into OOM issues after the increase to the default bufferPoolTrimThreshold in the d3d12TranslationLayer.