### PR TITLE
Allow passing any non-zero value to enable alpha test or fog

### DIFF
--- a/src/9on12PixelStage.cpp
+++ b/src/9on12PixelStage.cpp
@@ -577,7 +577,7 @@ namespace D3D9on12
         switch (dwState)
         {
         case D3DRS_ALPHATESTENABLE:
-            m_rasterStates.SetAlphaTestEnable(dwValue == TRUE);
+            m_rasterStates.SetAlphaTestEnable(dwValue != FALSE);
             break;
         case D3DRS_ALPHAFUNC:
             m_rasterStates.SetAlphaFunc(static_cast<D3DCMPFUNC>(dwValue));
@@ -587,7 +587,7 @@ namespace D3D9on12
             m_dirtyFlags.PSExtension = true;
             break;
         case D3DRS_FOGENABLE:
-            m_rasterStates.SetFogEnable(dwValue == TRUE);
+            m_rasterStates.SetFogEnable(dwValue != FALSE);
             break;
         case D3DRS_FOGCOLOR:
             ConvertToRGB(dwValue, m_PSExtension.vFogColor);


### PR DESCRIPTION
9on12 previously expected apps to pass an explicit TRUE (1) value for enabling alphaTest or fog. This is technically to spec, but some apps such as S.T.A.L.K.E.R. Shadow of Chernobyl would pass 0xFF instead with the intent to enable.

Went ahead and applied this change to FogEnable too for consistency since I wouldn't be surprised to hit that in the future.

Fixes #86