### PR TITLE
Changing use of raw ptr to CComPtr

### DIFF
--- a/ShaderConverter/ShaderConv/pch.h
+++ b/ShaderConverter/ShaderConv/pch.h
@@ -17,6 +17,7 @@
 #undef WIN32_LEAN_AND_MEAN
 
 #include <windows.h>
+#include <atlbase.h>
 #include <strsafe.h>
 #include <ShaderConvCommon.h>
 


### PR DESCRIPTION
`CCodeBlob` object was being leaked by not being released properly.

Replaced use of use of raw pointer to use `CComPtr` for managing its lifetime.

Fixes #65 