### PR TITLE
Add compat shim to disable INTZ fix for select apps that are incompatible

### DIFF
--- a/include/9on12draw.inl
+++ b/include/9on12draw.inl
@@ -47,7 +47,7 @@ namespace D3D9on12
     {
         // Data uploaded for a draw is only valid for that draw, and should be cleaned up immediately after to prevent
         // successive draws from reading stale/deleted data
-        if (device.GetPipelineState().GetIntzRestoreZWrite())
+        if (!g_AppCompatInfo.DisableIntzDSVFix && device.GetPipelineState().GetIntzRestoreZWrite())
         {
             device.GetPipelineState().GetPixelStage().SetDepthStencilState(device, D3DRS_ZWRITEENABLE, 1);
             device.GetPipelineState().SetIntzRestoreZWrite(false);

--- a/interface/d3d9on12ddi.h
+++ b/interface/d3d9on12ddi.h
@@ -287,6 +287,7 @@ typedef struct _D3D9ON12_APP_COMPAT_INFO
     DWORD MaxAllocatedUploadHeapSpacePerCommandList; // Maximum amount of storage allocated for upload operations per command list before flush
     DWORD MaxSRVHeapSize; // Maximum number of entries in the sharer resource view decriptor heap
     DWORD BufferPoolTrimThreshold; // How many fences (roughly translates to frames) a buffer in the buffer pool is allowed to exist before it is eleigible for being reclaimed. Must be in the range 5-100 to have an effect
+	DWORD DisableIntzDSVFix; // Disables the fix for INTZ DSV also bound as SRV that disables ZWrite instead of hiding SRV. Some apps (ex: GTAIV) actually require the opposite behavior. This is a workaround until "feedback loop" surfaces are possible in d3d12
 } D3D9ON12_APP_COMPAT_INFO;
 
 typedef void (APIENTRY *PFND3D9ON12_SETAPPCOMPATDATA)(

--- a/src/9on12AppCompat.cpp
+++ b/src/9on12AppCompat.cpp
@@ -12,6 +12,7 @@ namespace D3D9on12
         MAXDWORD, // MaxAllocatedUploadHeapSpacePerCommandList
         MAXDWORD, // MaxSRVHeapSize
         MAXDWORD, // BufferPoolTrimThreshold
+        0,        // DisableIntzDSVFix
     };
 
     void APIENTRY SetAppCompatData(const D3D9ON12_APP_COMPAT_INFO *pAppCompatData)

--- a/src/9on12PixelStage.cpp
+++ b/src/9on12PixelStage.cpp
@@ -901,7 +901,7 @@ namespace D3D9on12
                         bool HideSRV = pResource->GetDSVBindingTracker().IsBound() && GetDepthStencilStateID().ZWriteEnable;
 
                         // resources with INTZ surface format, set ZWriteEnable to false instead of hiding SRV
-                        if (HideSRV && (pResource->GetD3DFormat() == D3DFMT_INTZ))
+                        if (!g_AppCompatInfo.DisableIntzDSVFix && HideSRV && (pResource->GetD3DFormat() == D3DFMT_INTZ))
                         {
                             HideSRV = false;
                             SetDepthStencilState(device, D3DRS_ZWRITEENABLE, 0);


### PR DESCRIPTION
https://github.com/microsoft/D3D9On12/pull/40 added a fix where an INTZ DSV that was also bound as an SRV would disable Z writing rather than hiding the SRV. This fixed an issue for games like Cities: Skylines, but apparently breaks other games like GTAIV.

The real fix is complex and requires changes in d3d12. To unblock for now, we are going with a compat shim to disable the fix for specific games as needed.