### PR TITLE
Set D3DFORMAT_OP_NOALPHABLEND soley based on D3D12_FORMAT_SUPPORT1_BLENDABLE

### DIFF
--- a/src/9on12Adapter.cpp
+++ b/src/9on12Adapter.cpp
@@ -554,11 +554,10 @@ namespace D3D9on12
                         formatOperations |= __D3DFMTOP_RENDERTARGET;
                     }
 
-                    // If the format supports render target but not blending, report NOALPHABLEND
+                    // If the format is not blendable, report NOALPHABLEND
                     // so that CheckDeviceFormat with D3DUSAGE_QUERY_POSTPIXELSHADER_BLENDING
                     // correctly reflects hardware capability.
-                    if ((formatOperations & __D3DFMTOP_RENDERTARGET) &&
-                        !(dxgiFormatSupport.Support1 & D3D12_FORMAT_SUPPORT1_BLENDABLE))
+                    if (!(dxgiFormatSupport.Support1 & D3D12_FORMAT_SUPPORT1_BLENDABLE))
                     {
                         formatOperations |= D3DFORMAT_OP_NOALPHABLEND;
                     }


### PR DESCRIPTION
Ran a bunch of comparison format queries between native9 and 9on12 on my AMD GPU.

Main interesting results:
When just checking for `D3DUSAGE_QUERY_POSTPIXELSHADER_BLENDING`, the main difference was that native9 reported blendable for block compressed formats, while d3d12's checks don't support that. probably not an issue?

`D3DUSAGE_RENDERTARGET | D3DUSAGE_QUERY_POSTPIXELSHADER_BLENDING` check showed differences for bump map formats (eg: D3DFMT_Q8W8V8U8 or D3DFMT_V8U8) - 9on12 marks them as not RT while native 9 allows them as RT (on this device). Not changing this for now since there is a comment that indicates that this difference may cause test failures. Unsure of how IHV is working around this, but probably not a big deal.