### PR TITLE
Disable inlining for CHPE (arm64 with x86 ABI) builds

### DIFF
--- a/ShaderConverter/ShaderConv/context.cpp
+++ b/ShaderConverter/ShaderConv/context.cpp
@@ -18,6 +18,9 @@ namespace ShaderConv
 /// <summary>
 /// </summary>
 ///---------------------------------------------------------------------------
+#if defined(_CHPE_X86_ARM64_)
+#pragma inline_depth(0)
+#endif
 HRESULT
 CContext::TranslateInstructions()
 {
@@ -442,6 +445,9 @@ CContext::TranslateInstructions()
 
     return S_OK;
 }
+#if defined(_CHPE_X86_ARM64_)
+#pragma inline_depth()
+#endif
 
 ///---------------------------------------------------------------------------
 /// <summary>


### PR DESCRIPTION
Apparently the CHPE compiler likes to inline way too much which ends up bloating stack usage in a way that blows out the stack in some processes that use D3D9 on threads with small stack sizes.