### PR TITLE
Clang address of temporary in DerivedVertex

### DIFF
--- a/include/9on12Shader.h
+++ b/include/9on12Shader.h
@@ -212,7 +212,8 @@ namespace D3D9on12
             DerivedVertexShaderKey(const ShaderConv::RasterStates& rasterStates, InputLayout& inputLayout, _In_reads_(MAX_VERTEX_STREAMS) UINT* streamFrequencies) : DerivedShaderKey(rasterStates)
             {
                 //memcpy because assignment can add alignment which can throw off hashing
-                memcpy(&m_inputLayoutHash, &inputLayout.GetHash(), sizeof(m_inputLayoutHash));
+                WeakHash inputLayoutHash = inputLayout.GetHash();
+                memcpy(&m_inputLayoutHash, &inputLayoutHash, sizeof(m_inputLayoutHash));
                 memcpy(m_streamFrequencies, streamFrequencies, sizeof(m_streamFrequencies));
 
                 WeakHash hash = HashData(&m_rasterStates, sizeof(m_rasterStates), m_inputLayoutHash);//Add the hash from the IL


### PR DESCRIPTION
## Summary

`InputLayout::GetHash()` returns `WeakHash` **by value**, so `&inputLayout.GetHash()` takes the address of a prvalue temporary. Clang rejects this with `-Waddress-of-temporary` (errors by default).

Decided to fix this since this is the only AOT issue in this repo.