### PR TITLE
D3D9On12: pass nullptr to transient ResidencySet::Open

### DIFF
--- a/src/9on12Device.cpp
+++ b/src/9on12Device.cpp
@@ -305,7 +305,9 @@ namespace D3D9on12
             // Ensure that the resource is resident after the waits on the callers queue are satisfied.
             auto pResidencySet = std::make_unique<D3D12TranslationLayer::ResidencySet>();
 
-            pResidencySet->Open((UINT)D3D12TranslationLayer::COMMAND_LIST_TYPE::MAX_VALID);
+            // Transient set: lifetime is bounded to this call frame, so it cannot race with a destroyed
+            // Resource via ResidencyManager::EndTrackingObject. Pass nullptr to skip manager registration.
+            pResidencySet->Open((UINT)D3D12TranslationLayer::COMMAND_LIST_TYPE::MAX_VALID, nullptr);
             pResidencySet->Insert(pResidencyHandle);
             pResidencySet->Close();
 


### PR DESCRIPTION
## Problem

Consumer-side update to track the breaking signature change for `D3D12TranslationLayer::ResidencySet::Open()` introduced in:

- https://github.com/microsoft/D3D12TranslationLayer/pull/114



See that PR for full root-cause analysis.



## Change

`D3D9on12::Device::UnwrapResource` (9on12Device.cpp:308) constructs a transient `ResidencySet`, opens it on the `MAX_VALID` (transient) command-list slot, inserts one residency handle, closes, and submits â€” all in a single call frame on the same thread. The set is never visible to `EndTrackingObject`, so manager registration is pure overhead.



Passing `nullptr` for the new `ResidencyManager*` parameter opts this call site into the "no tracking, no locking" mode, matching its actual lifetime.



```diff

-            pResidencySet->Open((UINT)D3D12TranslationLayer::COMMAND_LIST_TYPE::MAX_VALID);

+            // Transient set: lifetime is bounded to this call frame, so it cannot race with a destroyed

+            // Resource via ResidencyManager::EndTrackingObject. Pass nullptr to skip manager registration.

+            pResidencySet->Open((UINT)D3D12TranslationLayer::COMMAND_LIST_TYPE::MAX_VALID, nullptr);

```



## Dependencies

- **https://github.com/microsoft/D3D12TranslationLayer/pull/114 must merge first** (defines the new 2-arg signature). This PR's CI will not pass against the current `D3D12TranslationLayer:master` until that lands and the submodule pointer here is bumped.



## Verification

Compile-clean build of `d3d9on12.dll` (Debug x64) against the updated `D3D12TranslationLayer` branch. Same `d3d9on12.dll` was used for the end-to-end TAEF repro in the D3D12TranslationLayer PR's verification section (the test that exercises the underlying UAF runs through this DLL).



## Pre-empted review questions

- **Behavior change at this call site?** None â€” the transient set never had a real concurrent-destroy exposure; `nullptr` just removes the overhead the new tracking would otherwise add.

- **Regression risk?** None â€” mechanical 1-line change, same lock-free fast path as before.

